### PR TITLE
model loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .venv
 .idea
 gecco
+__pycache__

--- a/bertblocks/__init__.py
+++ b/bertblocks/__init__.py
@@ -12,7 +12,7 @@ The models are compatible with HuggingFace transformers ecosystem.
 """
 
 from bertblocks.config import BertBlocksConfig
-from bertblocks.integration import from_huggingface
+from bertblocks.integration import from_huggingface, from_model
 from bertblocks.modeling.model import (
     BertBlocksForMaskedDiffusion,
     BertBlocksForMaskedLM,
@@ -65,4 +65,5 @@ __all__ = [
     "BertBlocksPretrainingDataModule",
     "BertBlocksPretrainingModule",
     "from_huggingface",
+    "from_model",
 ]

--- a/bertblocks/config/__init__.py
+++ b/bertblocks/config/__init__.py
@@ -1,6 +1,6 @@
 from typing import Any, Literal
 
-from transformers import AutoConfig, PreTrainedConfig
+from transformers import AutoConfig, AutoTokenizer, BertConfig, ModernBertConfig, PreTrainedConfig
 
 NormalizationFunction = Literal["group", "layer", "rms", "deep", "dynamictanh"]
 NormalizationPosition = Literal["pre", "post", "both", "none"]
@@ -434,56 +434,53 @@ class BertBlocksConfig(PreTrainedConfig):
                     f"invalid block_pos_enc_kind: expected one of {valid_block_enc} or None, got {block_pos_enc_kind!r}"
                 )
 
+    @classmethod
+    def from_huggingface_bert(
+        cls,
+        pretrained_model_name_or_path: str,
+        attn_implementation: Literal["flash_attention_2", "sdpa", "eager"] = "sdpa",
+    ) -> "BertBlocksConfig":
+        """Instantiate a BertBlocksConfig from a pretrained HuggingFace BERT config."""
+        orig_config = BertConfig.from_pretrained(pretrained_model_name_or_path)
+        orig_config.name_or_path = pretrained_model_name_or_path
+        config = cls.from_bert_config(orig_config)
+        config._attn_implementation = attn_implementation
+        config._unpadding = attn_implementation == "flash_attention_2"
+        return config
 
-class BertConfig(BertBlocksConfig):
-    """BertBlocksConfig with default arguments applied for Bert architecture."""
+    @classmethod
+    def from_bert_config(cls, orig_config: BertConfig) -> "BertBlocksConfig":
+        """Instantiate a BertBlocksConfig from a HuggingFace BERT config object."""
+        if not hasattr(orig_config, "mask_token_id") or orig_config.mask_token_id is None:
+            tok = AutoTokenizer.from_pretrained(orig_config.name_or_path)
+            mask_token_id = tok.mask_token_id
+        else:
+            mask_token_id = orig_config.mask_token_id
 
-    model_type = "bert"
+        pos_enc_kind = getattr(orig_config, "position_embedding_type", "absolute")
+        emb_pos_enc_kind = "learned" if pos_enc_kind in ("absolute", "learned") else None
 
-    def __init__(
-        self,
-        vocab_size: int = 28996,
-        max_sequence_length: int = 512,
-        pad_token_id: int = 0,
-        mask_token_id: int = 103,
-        hidden_size: int = 768,
-        num_blocks: int = 12,
-        intermediate_size: int = 3072,
-        num_attention_heads: int = 12,
-        pos_enc_kind: Literal["learned", "absolute"] = "absolute",
-        type_vocab_size: int = 2,
-        initializer_range: float = 0.02,
-        actv_fn: Literal["relu", "silu", "gelu", "leakyrelu", "selu", "logsigmoid", "sigmoid", "prelu"] = "gelu",
-        norm_eps: float = 1e-12,
-        emb_dropout_prob: float = 0.1,
-        attn_dropout_prob: float = 0.1,
-        hidden_dropout_prob: float = 0.1,
-        classifier_dropout_prob: float = 0.1,
-        attn_implementation: Literal["flash_attention_2", "eager", "sdpa"] = "flash_attention_2",
-    ):
-        super().__init__(
-            # User-configurable args
-            vocab_size=vocab_size,
-            max_sequence_length=max_sequence_length,
-            pad_token_id=pad_token_id,
+        return cls(
+            vocab_size=orig_config.vocab_size,
+            max_sequence_length=orig_config.max_position_embeddings,
+            pad_token_id=orig_config.pad_token_id,
             mask_token_id=mask_token_id,
-            hidden_size=hidden_size,
-            num_blocks=num_blocks,
-            intermediate_size=intermediate_size,
-            num_attention_heads=num_attention_heads,
-            emb_pos_enc_kind="learned" if pos_enc_kind in ("absolute", "learned") else None,
+            hidden_size=orig_config.hidden_size,
+            num_blocks=orig_config.num_hidden_layers,
+            intermediate_size=orig_config.intermediate_size,
+            num_attention_heads=orig_config.num_attention_heads,
+            emb_pos_enc_kind=emb_pos_enc_kind,
             block_pos_enc_kind=None,
             attention_gate=None,
-            type_vocab_size=type_vocab_size,
-            initializer_range=initializer_range,
-            actv_fn=actv_fn,
-            norm_eps=norm_eps,
-            emb_dropout_prob=emb_dropout_prob or 0.0,
-            attn_dropout_prob=attn_dropout_prob or 0.0,
-            hidden_dropout_prob=hidden_dropout_prob or 0.0,
-            classifier_dropout_prob=classifier_dropout_prob or 0.0,
-            attn_implementation=attn_implementation,
-            # Hardcoded args for architecture compatibility
+            type_vocab_size=orig_config.type_vocab_size,
+            initializer_range=orig_config.initializer_range,
+            actv_fn=orig_config.hidden_act,
+            norm_eps=orig_config.layer_norm_eps,
+            emb_dropout_prob=orig_config.hidden_dropout_prob or 0.0,
+            attn_dropout_prob=orig_config.attention_probs_dropout_prob or 0.0,
+            hidden_dropout_prob=orig_config.hidden_dropout_prob or 0.0,
+            classifier_dropout_prob=orig_config.classifier_dropout or 0.0,
+            # Hardcoded args for BERT architecture compatibility
             residual_first_layer=False,
             add_token_type_emb=True,
             mlp_type="mlp",
@@ -501,128 +498,24 @@ class BertConfig(BertBlocksConfig):
         )
 
     @classmethod
-    def from_huggingface(
+    def from_huggingface_modernbert(
         cls,
         pretrained_model_name_or_path: str,
         attn_implementation: Literal["flash_attention_2", "sdpa", "eager"] = "sdpa",
-    ) -> "BertConfig":
-        """Instantiate an equivalent BertBlocks BertConfig from a pretrained HuggingFace config."""
-        from transformers import BertConfig
-
-        orig_config = BertConfig.from_pretrained(pretrained_model_name_or_path)
-
-        if not hasattr(orig_config, "mask_token_id"):
-            tok = AutoTokenizer.from_pretrained(pretrained_model_name_or_path)
-            mask_token_id = tok.mask_token_id
-        else:
-            mask_token_id = orig_config.mask_token_id
-
-        return cls(
-            vocab_size=orig_config.vocab_size,
-            max_sequence_length=orig_config.max_position_embeddings,
-            pad_token_id=orig_config.pad_token_id,
-            mask_token_id=mask_token_id,
-            hidden_size=orig_config.hidden_size,
-            num_blocks=orig_config.num_hidden_layers,
-            intermediate_size=orig_config.intermediate_size,
-            num_attention_heads=orig_config.num_attention_heads,
-            pos_enc_kind=orig_config.position_embedding_type,
-            type_vocab_size=orig_config.type_vocab_size,
-            initializer_range=orig_config.initializer_range,
-            actv_fn=orig_config.hidden_act,
-            norm_eps=orig_config.layer_norm_eps,
-            emb_dropout_prob=orig_config.hidden_dropout_prob or 0.0,
-            attn_dropout_prob=orig_config.attention_probs_dropout_prob or 0.0,
-            hidden_dropout_prob=orig_config.hidden_dropout_prob or 0.0,
-            classifier_dropout_prob=orig_config.classifier_dropout or 0.0,
-            attn_implementation=attn_implementation,
-        )
-
-
-class ModernBertConfig(BertBlocksConfig):
-    """BertBlocksConfig with default arguments applied for ModernBert architecture."""
-
-    model_type = "modernbert"
-
-    def __init__(
-        self,
-        vocab_size: int,
-        max_sequence_length: int,
-        pad_token_id: int,
-        mask_token_id: int,
-        hidden_size: int,
-        num_blocks: int,
-        intermediate_size: int,
-        num_attention_heads: int,
-        block_pos_enc_kwargs: dict[str, Any],
-        mlp_in_bias: bool,
-        mlp_out_bias: bool,
-        attn_proj_bias: bool,
-        attn_out_bias: bool,
-        local_attention: tuple[int, int],
-        global_attention_every_n_layers: int,
-        initializer_range: float,
-        actv_fn: Literal["relu", "silu", "gelu", "leakyrelu", "selu", "logsigmoid", "sigmoid", "prelu"],
-        norm_eps: float,
-        norm_bias: bool,
-        emb_dropout_prob: float,
-        attn_dropout_prob: float,
-        hidden_dropout_prob: float,
-        classifier_dropout_prob: float,
-        attn_implementation: Literal["flash_attention_2", "eager", "sdpa"] = "flash_attention_2",
-    ):
-        super().__init__(
-            vocab_size=vocab_size,
-            max_sequence_length=max_sequence_length,
-            pad_token_id=pad_token_id,
-            mask_token_id=mask_token_id,
-            hidden_size=hidden_size,
-            num_blocks=num_blocks,
-            intermediate_size=intermediate_size,
-            num_attention_heads=num_attention_heads,
-            block_pos_enc_kwargs=block_pos_enc_kwargs,
-            mlp_in_bias=mlp_in_bias,
-            mlp_out_bias=mlp_out_bias,
-            attn_proj_bias=attn_proj_bias,
-            attn_out_bias=attn_out_bias,
-            local_attention=local_attention,
-            global_attention_every_n_layers=global_attention_every_n_layers,
-            initializer_range=initializer_range,
-            actv_fn=actv_fn,
-            norm_eps=norm_eps,
-            norm_bias=norm_bias,
-            emb_dropout_prob=emb_dropout_prob,
-            attn_dropout_prob=attn_dropout_prob,
-            hidden_dropout_prob=hidden_dropout_prob,
-            classifier_dropout_prob=classifier_dropout_prob,
-            attn_implementation=attn_implementation,
-            # Hard-coded values for architecture compatibility
-            attention_gate=None,
-            residual_first_layer=True,
-            block_pos_enc_kind="rope",
-            add_token_type_emb=False,
-            mlp_type="glu",
-            initializer_kind="trunc_normal",
-            initializer_cutoff_factor=4.0,
-            initializer_gain=1.0,
-            norm_kind="pre",
-            norm_fn="layer",
-            include_final_norm=True,
-            norm_qk=False,
-        )
+    ) -> "BertBlocksConfig":
+        """Instantiate a BertBlocksConfig from a pretrained HuggingFace ModernBERT config."""
+        orig_config = ModernBertConfig.from_pretrained(pretrained_model_name_or_path)
+        orig_config.name_or_path = pretrained_model_name_or_path
+        config = cls.from_modernbert_config(orig_config)
+        config._attn_implementation = attn_implementation
+        config._unpadding = attn_implementation == "flash_attention_2"
+        return config
 
     @classmethod
-    def from_huggingface(
-        cls,
-        pretrained_model_name_or_path: str,
-        attn_implementation: Literal["flash_attention_2", "sdpa", "eager"] = "flash_attention_2",
-    ) -> "ModernBertConfig":
-        """Instantiate an equivalent BertBlocks ModernBertConfig from a pretrained HuggingFace config."""
-        from transformers import ModernBertConfig
-
-        orig_config = ModernBertConfig.from_pretrained(pretrained_model_name_or_path)
-        if not hasattr(orig_config, "mask_token_id"):
-            tok = AutoTokenizer.from_pretrained(pretrained_model_name_or_path)
+    def from_modernbert_config(cls, orig_config: ModernBertConfig) -> "BertBlocksConfig":
+        """Instantiate a BertBlocksConfig from a HuggingFace ModernBERT config object."""
+        if not hasattr(orig_config, "mask_token_id") or orig_config.mask_token_id is None:
+            tok = AutoTokenizer.from_pretrained(orig_config.name_or_path)
             mask_token_id = tok.mask_token_id
         else:
             mask_token_id = orig_config.mask_token_id
@@ -637,8 +530,8 @@ class ModernBertConfig(BertBlocksConfig):
             intermediate_size=orig_config.intermediate_size,
             num_attention_heads=orig_config.num_attention_heads,
             block_pos_enc_kwargs={
-                "base_global": orig_config.global_rope_theta,
-                "base_local": orig_config.local_rope_theta,
+                "base_global": orig_config.rope_parameters["full_attention"]["rope_theta"],
+                "base_local": orig_config.rope_parameters["sliding_attention"]["rope_theta"],
                 "scale": 1,
             },
             mlp_in_bias=orig_config.mlp_bias,
@@ -659,8 +552,56 @@ class ModernBertConfig(BertBlocksConfig):
             attn_dropout_prob=orig_config.attention_dropout or 0.0,
             hidden_dropout_prob=orig_config.mlp_dropout or 0.0,
             classifier_dropout_prob=orig_config.classifier_dropout or 0.0,
-            attn_implementation=attn_implementation,
+            # Hardcoded args for ModernBERT architecture compatibility
+            attention_gate=None,
+            residual_first_layer=True,
+            block_pos_enc_kind="rope",
+            add_token_type_emb=False,
+            mlp_type="glu",
+            initializer_kind="trunc_normal",
+            initializer_cutoff_factor=4.0,
+            initializer_gain=1.0,
+            norm_kind="pre",
+            norm_fn="layer",
+            include_final_norm=True,
+            norm_qk=False,
         )
 
+    @classmethod
+    def from_config(
+        cls,
+        orig_config: PreTrainedConfig,
+    ) -> "BertBlocksConfig":
+        """Instantiate a BertBlocksConfig from any supported HuggingFace config object.
 
-__all__ = ["BertBlocksConfig", "BertConfig", "ModernBertConfig"]
+        Dispatches to the appropriate from_*_config method based on the config type.
+        Supported config types: BertConfig, ModernBertConfig.
+        """
+        if isinstance(orig_config, BertConfig):
+            return cls.from_bert_config(orig_config)
+        if isinstance(orig_config, ModernBertConfig):
+            return cls.from_modernbert_config(orig_config)
+        raise ValueError(
+            f"Unsupported config type: {type(orig_config).__name__}. Supported types: BertConfig, ModernBertConfig"
+        )
+
+    @classmethod
+    def from_huggingface(
+        cls,
+        pretrained_model_name_or_path: str,
+        attn_implementation: Literal["flash_attention_2", "sdpa", "eager"] = "sdpa",
+    ) -> "BertBlocksConfig":
+        """Instantiate a BertBlocksConfig from any supported pretrained HuggingFace model.
+
+        Automatically detects the model type and dispatches to the appropriate method.
+        Supported model types: BERT, ModernBERT.
+        """
+        orig_config = AutoConfig.from_pretrained(pretrained_model_name_or_path)
+        orig_config.name_or_path = pretrained_model_name_or_path
+        config = cls.from_config(orig_config)
+        config._attn_implementation = attn_implementation
+        config._unpadding = attn_implementation == "flash_attention_2"
+        return config
+
+
+__all__ = ["BertBlocksConfig"]

--- a/bertblocks/config/__init__.py
+++ b/bertblocks/config/__init__.py
@@ -571,6 +571,7 @@ class BertBlocksConfig(PreTrainedConfig):
     def from_config(
         cls,
         orig_config: PreTrainedConfig,
+        attn_implementation: Literal["flash_attention_2", "sdpa", "eager"] = "sdpa",
     ) -> "BertBlocksConfig":
         """Instantiate a BertBlocksConfig from any supported HuggingFace config object.
 
@@ -578,12 +579,18 @@ class BertBlocksConfig(PreTrainedConfig):
         Supported config types: BertConfig, ModernBertConfig.
         """
         if isinstance(orig_config, BertConfig):
-            return cls.from_bert_config(orig_config)
-        if isinstance(orig_config, ModernBertConfig):
-            return cls.from_modernbert_config(orig_config)
-        raise ValueError(
-            f"Unsupported config type: {type(orig_config).__name__}. Supported types: BertConfig, ModernBertConfig"
-        )
+            config = cls.from_bert_config(orig_config)
+            config._attn_implementation = attn_implementation
+            config._unpadding = attn_implementation == "flash_attention_2"
+        elif isinstance(orig_config, ModernBertConfig):
+            config = cls.from_modernbert_config(orig_config)
+        else:
+            raise ValueError(
+                f"Unsupported config type: {type(orig_config).__name__}. Supported types: BertConfig, ModernBertConfig"
+            )
+        config._attn_implementation = attn_implementation
+        config._unpadding = attn_implementation == "flash_attention_2"
+        return config
 
     @classmethod
     def from_huggingface(

--- a/bertblocks/integration/__init__.py
+++ b/bertblocks/integration/__init__.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     from bertblocks.modeling.model import BertBlocksModel
@@ -10,7 +10,10 @@ from .load_modernbert import from_huggingface_modernbert_model, from_modernbert_
 
 
 def from_huggingface(
-    pretrained_model_name_or_path: str, load_weights: bool = True, add_pooling_layer: bool = False
+    pretrained_model_name_or_path: str,
+    load_weights: bool = True,
+    add_pooling_layer: bool = False,
+    attn_implementation: Literal["flash_attention_2", "sdpa", "eager"] = "sdpa",
 ) -> "BertBlocksModel":
     """Instantiate an equivalent BertBlocksModel from HuggingFace pretrained models.
 
@@ -25,6 +28,8 @@ def from_huggingface(
             a fresh model with random weights. Defaults to True.
         add_pooling_layer (bool, optional): Whether to add a pooling layer that processes the [CLS] token.
             Useful for sequence-level classification tasks. Defaults to False.
+        attn_implementation (str, optional): Attention backend. One of "flash_attention_2", "sdpa", or
+            "eager". Defaults to "sdpa".
 
     Returns:
         BertBlocksModel: A BertBlocks model with architecture matched to the source HuggingFace model,
@@ -37,17 +42,27 @@ def from_huggingface(
     match config.model_type:
         case "bert":
             return from_huggingface_bert_model(
-                pretrained_model_name_or_path, load_weights=load_weights, add_pooling_layer=add_pooling_layer
+                pretrained_model_name_or_path,
+                load_weights=load_weights,
+                add_pooling_layer=add_pooling_layer,
+                attn_implementation=attn_implementation,
             )
         case "modernbert":
             return from_huggingface_modernbert_model(
-                pretrained_model_name_or_path, load_weights=load_weights, add_pooling_layer=add_pooling_layer
+                pretrained_model_name_or_path,
+                load_weights=load_weights,
+                add_pooling_layer=add_pooling_layer,
+                attn_implementation=attn_implementation,
             )
         case _:
             raise ValueError(f"Unsupported model_type: {config.model_type}. Supported types: bert, modernbert")
 
 
-def from_model(model: PreTrainedModel, add_pooling_layer: bool = False) -> "BertBlocksModel":
+def from_model(
+    model: PreTrainedModel,
+    add_pooling_layer: bool = False,
+    attn_implementation: Literal["flash_attention_2", "sdpa", "eager"] = "sdpa",
+) -> "BertBlocksModel":
     """Instantiate a BertBlocksModel from an already loaded HuggingFace model instance.
 
     Automatically detects the model type and dispatches to the appropriate conversion function.
@@ -55,6 +70,8 @@ def from_model(model: PreTrainedModel, add_pooling_layer: bool = False) -> "Bert
     Args:
         model (PreTrainedModel): An instance of a HuggingFace PreTrainedModel.
         add_pooling_layer (bool, optional): Whether to add a pooling layer. Defaults to False.
+        attn_implementation (str, optional): Attention backend. One of "flash_attention_2", "sdpa", or
+            "eager". Defaults to "sdpa".
 
     Returns:
         BertBlocksModel: A BertBlocks model with architecture and weights matched to the source model.
@@ -65,9 +82,11 @@ def from_model(model: PreTrainedModel, add_pooling_layer: bool = False) -> "Bert
     from transformers import ModernBertModel
 
     if isinstance(model, BertModel):
-        return from_bert_model(model, add_pooling_layer=add_pooling_layer)
+        return from_bert_model(model, add_pooling_layer=add_pooling_layer, attn_implementation=attn_implementation)
     if isinstance(model, ModernBertModel):
-        return from_modernbert_model(model, add_pooling_layer=add_pooling_layer)
+        return from_modernbert_model(
+            model, add_pooling_layer=add_pooling_layer, attn_implementation=attn_implementation
+        )
     raise ValueError(f"Unsupported model type: {type(model).__name__}. Supported types: BertModel, ModernBertModel")
 
 

--- a/bertblocks/integration/__init__.py
+++ b/bertblocks/integration/__init__.py
@@ -3,10 +3,10 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from bertblocks.modeling.model import BertBlocksModel
 
-from transformers import AutoConfig
+from transformers import AutoConfig, BertModel, PreTrainedModel
 
-from .load_bert import from_bert_model
-from .load_modernbert import from_modernbert_model
+from .load_bert import from_bert_model, from_huggingface_bert_model
+from .load_modernbert import from_huggingface_modernbert_model, from_modernbert_model
 
 
 def from_huggingface(
@@ -32,34 +32,43 @@ def from_huggingface(
 
     Raises:
         ValueError: If the model type is not supported or cannot be detected.
-        OSError: If the model path does not exist or is not accessible.
-        ImportError: If required HuggingFace transformers models are not installed.
-
-    Supported Models:
-        - BERT and variants (bert-base-uncased, bert-large-uncased, etc.)
-        - ModernBERT (modernbert-base, modernbert-large, etc.)
-        - Other BERT-like encoder models compatible with HuggingFace
-
-    Example:
-        >>> from bertblocks.integration import from_huggingface
-        >>> # Load BERT model
-        >>> bert_model = from_huggingface("bert-base-uncased")
-        >>> # Load ModernBERT model
-        >>> modernbert_model = from_huggingface("modernbert-base")
-        >>> # Load without transferring weights
-        >>> fresh_model = from_huggingface("bert-base-uncased", load_weights=False)
-
-    References:
-        - HuggingFace Model Hub: https://huggingface.co/models
     """
     config = AutoConfig.from_pretrained(pretrained_model_name_or_path)
     match config.model_type:
+        case "bert":
+            return from_huggingface_bert_model(
+                pretrained_model_name_or_path, load_weights=load_weights, add_pooling_layer=add_pooling_layer
+            )
         case "modernbert":
-            return from_modernbert_model(
+            return from_huggingface_modernbert_model(
                 pretrained_model_name_or_path, load_weights=load_weights, add_pooling_layer=add_pooling_layer
             )
         case _:
-            raise ValueError(f"Unknown model_type {config.model_type}")
+            raise ValueError(f"Unsupported model_type: {config.model_type}. Supported types: bert, modernbert")
 
 
-__all__ = ["from_huggingface"]
+def from_model(model: PreTrainedModel, add_pooling_layer: bool = False) -> "BertBlocksModel":
+    """Instantiate a BertBlocksModel from an already loaded HuggingFace model instance.
+
+    Automatically detects the model type and dispatches to the appropriate conversion function.
+
+    Args:
+        model (PreTrainedModel): An instance of a HuggingFace PreTrainedModel.
+        add_pooling_layer (bool, optional): Whether to add a pooling layer. Defaults to False.
+
+    Returns:
+        BertBlocksModel: A BertBlocks model with architecture and weights matched to the source model.
+
+    Raises:
+        ValueError: If the model type is not supported or cannot be detected.
+    """
+    from transformers import ModernBertModel
+
+    if isinstance(model, BertModel):
+        return from_bert_model(model, add_pooling_layer=add_pooling_layer)
+    if isinstance(model, ModernBertModel):
+        return from_modernbert_model(model, add_pooling_layer=add_pooling_layer)
+    raise ValueError(f"Unsupported model type: {type(model).__name__}. Supported types: BertModel, ModernBertModel")
+
+
+__all__ = ["from_huggingface", "from_model"]

--- a/bertblocks/integration/load_bert.py
+++ b/bertblocks/integration/load_bert.py
@@ -1,12 +1,13 @@
 import torch
+from transformers import BertModel
 
-from bertblocks.config import BertConfig
+from bertblocks.config import BertBlocksConfig
 from bertblocks.modeling.model import BertBlocksModel
 
 
-def from_bert_model(
+def from_huggingface_bert_model(
     pretrained_model_name_or_path: str, load_weights: bool = True, add_pooling_layer: bool = False
-) -> "BertBlocksModel":
+) -> BertBlocksModel:
     """Instantiate an equivalent BertBlocks model from pretrained HuggingFace BERT weights and config.
 
     Converts a HuggingFace BERT model to BertBlocks architecture with optional weight transfer.
@@ -45,77 +46,100 @@ def from_bert_model(
         - "BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding"
           (https://arxiv.org/abs/1810.04805)
     """
-    from transformers import BertModel
-
-    bertblocks_config = BertConfig.from_huggingface(pretrained_model_name_or_path)
+    bertblocks_config = BertBlocksConfig.from_huggingface_bert(pretrained_model_name_or_path)
     bertblocks_model = BertBlocksModel(bertblocks_config, add_pooling_layer=add_pooling_layer)
 
     if load_weights:
         orig_model = BertModel.from_pretrained(pretrained_model_name_or_path, add_pooling_layer=add_pooling_layer)
+        bertblocks_model = from_bert_model(orig_model, add_pooling_layer=add_pooling_layer)
 
-        # Embedding layer
-        bertblocks_model.embd.embd.weight.data.copy_(orig_model.embeddings.word_embeddings.weight.data)
-        bertblocks_model.embd.pose.embd.weight.data.copy_(orig_model.embeddings.position_embeddings.weight.data)
-        bertblocks_model.embd.norm.weight.data.copy_(orig_model.embeddings.LayerNorm.weight.data)
-        bertblocks_model.embd.norm.bias.data.copy_(orig_model.embeddings.LayerNorm.bias.data)
-        bertblocks_model.embd.tokt.embd.weight.data.copy_(orig_model.embeddings.token_type_embeddings.weight.data)  # type: ignore
+    return bertblocks_model
 
-        for i in range(len(bertblocks_model.encd.blocks)):
-            # QKV Projection
-            qkv_weight = torch.cat(
-                [
-                    orig_model.encoder.layer[i].attention.self.query.weight,
-                    orig_model.encoder.layer[i].attention.self.key.weight,
-                    orig_model.encoder.layer[i].attention.self.value.weight,
-                ],
-                dim=0,
-            )
-            qkv_bias = torch.cat(
-                [
-                    orig_model.encoder.layer[i].attention.self.query.bias,
-                    orig_model.encoder.layer[i].attention.self.key.bias,
-                    orig_model.encoder.layer[i].attention.self.value.bias,
-                ],
-                dim=0,
-            )
 
-            bertblocks_model.encd.blocks[i].attn.proj.weight.data.copy_(qkv_weight.data)
-            bertblocks_model.encd.blocks[i].attn.proj.bias.data.copy_(qkv_bias.data)
+def from_bert_model(orig_model: BertModel, add_pooling_layer: bool = False) -> BertBlocksModel:
+    """Instantiate an equivalent BertBlocks model from a HuggingFace BERT model instance.
 
-            # Attention output projection
-            bertblocks_model.encd.blocks[i].attn.ffwd.weight.data.copy_(
-                orig_model.encoder.layer[i].attention.output.dense.weight.data
-            )
-            bertblocks_model.encd.blocks[i].attn.ffwd.bias.data.copy_(
-                orig_model.encoder.layer[i].attention.output.dense.bias.data
-            )
+    Converts a HuggingFace BERT model to BertBlocks architecture with weight transfer.
+    The BertBlocks model uses post-normalization and standard MLP architecture to match BERT.
 
-            # Feed-forward layers
-            bertblocks_model.encd.blocks[i].ffwd.uprj.weight.data.copy_(
-                orig_model.encoder.layer[i].intermediate.dense.weight.data
-            )
-            bertblocks_model.encd.blocks[i].ffwd.uprj.bias.data.copy_(
-                orig_model.encoder.layer[i].intermediate.dense.bias.data
-            )
-            bertblocks_model.encd.blocks[i].ffwd.dprj.weight.data.copy_(
-                orig_model.encoder.layer[i].output.dense.weight.data
-            )
-            bertblocks_model.encd.blocks[i].ffwd.dprj.bias.data.copy_(
-                orig_model.encoder.layer[i].output.dense.bias.data
-            )
+    Args:
+        orig_model (BertModel): An instance of a HuggingFace BertModel that has been
+            loaded with pretrained weights.
+        add_pooling_layer (bool, optional): Whether to add a pooling layer that processes the
+            [CLS] token. Defaults to False.
 
-            # Layer norms
-            bertblocks_model.encd.blocks[i].post_norm_attn.weight.data.copy_(
-                orig_model.encoder.layer[i].attention.output.LayerNorm.weight.data
-            )
-            bertblocks_model.encd.blocks[i].post_norm_attn.bias.data.copy_(
-                orig_model.encoder.layer[i].attention.output.LayerNorm.bias.data
-            )
-            bertblocks_model.encd.blocks[i].post_norm_ffwd.weight.data.copy_(
-                orig_model.encoder.layer[i].output.LayerNorm.weight.data
-            )
-            bertblocks_model.encd.blocks[i].post_norm_ffwd.bias.data.copy_(
-                orig_model.encoder.layer[i].output.LayerNorm.bias.data
-            )
+    Returns:
+        BertBlocksModel: A BertBlocks model with architecture matched to BERT,
+            loaded with pretrained weights.
+
+    References:
+        - "BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding"
+          (https://arxiv.org/abs/1810.04805)
+    """
+    bertblocks_config = BertBlocksConfig.from_config(orig_model.config)
+    bertblocks_model = BertBlocksModel(bertblocks_config, add_pooling_layer=add_pooling_layer)
+
+    # Embedding layer
+    bertblocks_model.embd.embd.weight.data.copy_(orig_model.embeddings.word_embeddings.weight.data)
+    bertblocks_model.embd.pose.embd.weight.data.copy_(orig_model.embeddings.position_embeddings.weight.data)
+    bertblocks_model.embd.norm.weight.data.copy_(orig_model.embeddings.LayerNorm.weight.data)
+    bertblocks_model.embd.norm.bias.data.copy_(orig_model.embeddings.LayerNorm.bias.data)
+    bertblocks_model.embd.tokt.embd.weight.data.copy_(orig_model.embeddings.token_type_embeddings.weight.data)  # type: ignore
+
+    for i in range(len(bertblocks_model.encd.blocks)):
+        # QKV Projection
+        qkv_weight = torch.cat(
+            [
+                orig_model.encoder.layer[i].attention.self.query.weight,
+                orig_model.encoder.layer[i].attention.self.key.weight,
+                orig_model.encoder.layer[i].attention.self.value.weight,
+            ],
+            dim=0,
+        )
+        qkv_bias = torch.cat(
+            [
+                orig_model.encoder.layer[i].attention.self.query.bias,
+                orig_model.encoder.layer[i].attention.self.key.bias,
+                orig_model.encoder.layer[i].attention.self.value.bias,
+            ],
+            dim=0,
+        )
+
+        bertblocks_model.encd.blocks[i].attn.proj.weight.data.copy_(qkv_weight.data)
+        bertblocks_model.encd.blocks[i].attn.proj.bias.data.copy_(qkv_bias.data)
+
+        # Attention output projection
+        bertblocks_model.encd.blocks[i].attn.ffwd.weight.data.copy_(
+            orig_model.encoder.layer[i].attention.output.dense.weight.data
+        )
+        bertblocks_model.encd.blocks[i].attn.ffwd.bias.data.copy_(
+            orig_model.encoder.layer[i].attention.output.dense.bias.data
+        )
+
+        # Feed-forward layers
+        bertblocks_model.encd.blocks[i].ffwd.uprj.weight.data.copy_(
+            orig_model.encoder.layer[i].intermediate.dense.weight.data
+        )
+        bertblocks_model.encd.blocks[i].ffwd.uprj.bias.data.copy_(
+            orig_model.encoder.layer[i].intermediate.dense.bias.data
+        )
+        bertblocks_model.encd.blocks[i].ffwd.dprj.weight.data.copy_(
+            orig_model.encoder.layer[i].output.dense.weight.data
+        )
+        bertblocks_model.encd.blocks[i].ffwd.dprj.bias.data.copy_(orig_model.encoder.layer[i].output.dense.bias.data)
+
+        # Layer norms
+        bertblocks_model.encd.blocks[i].post_norm_attn.weight.data.copy_(
+            orig_model.encoder.layer[i].attention.output.LayerNorm.weight.data
+        )
+        bertblocks_model.encd.blocks[i].post_norm_attn.bias.data.copy_(
+            orig_model.encoder.layer[i].attention.output.LayerNorm.bias.data
+        )
+        bertblocks_model.encd.blocks[i].post_norm_ffwd.weight.data.copy_(
+            orig_model.encoder.layer[i].output.LayerNorm.weight.data
+        )
+        bertblocks_model.encd.blocks[i].post_norm_ffwd.bias.data.copy_(
+            orig_model.encoder.layer[i].output.LayerNorm.bias.data
+        )
 
     return bertblocks_model

--- a/bertblocks/integration/load_bert.py
+++ b/bertblocks/integration/load_bert.py
@@ -51,18 +51,14 @@ def from_huggingface_bert_model(
         - "BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding"
           (https://arxiv.org/abs/1810.04805)
     """
+    if load_weights:
+        orig_model = BertModel.from_pretrained(pretrained_model_name_or_path, add_pooling_layer=add_pooling_layer)
+        return from_bert_model(orig_model, add_pooling_layer=add_pooling_layer, attn_implementation=attn_implementation)
+
     bertblocks_config = BertBlocksConfig.from_huggingface_bert(
         pretrained_model_name_or_path, attn_implementation=attn_implementation
     )
-    bertblocks_model = BertBlocksModel(bertblocks_config, add_pooling_layer=add_pooling_layer)
-
-    if load_weights:
-        orig_model = BertModel.from_pretrained(pretrained_model_name_or_path, add_pooling_layer=add_pooling_layer)
-        bertblocks_model = from_bert_model(
-            orig_model, add_pooling_layer=add_pooling_layer, attn_implementation=attn_implementation
-        )
-
-    return bertblocks_model
+    return BertBlocksModel(bertblocks_config, add_pooling_layer=add_pooling_layer)
 
 
 def from_bert_model(

--- a/bertblocks/integration/load_bert.py
+++ b/bertblocks/integration/load_bert.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 import torch
 from transformers import BertModel
 
@@ -6,7 +8,10 @@ from bertblocks.modeling.model import BertBlocksModel
 
 
 def from_huggingface_bert_model(
-    pretrained_model_name_or_path: str, load_weights: bool = True, add_pooling_layer: bool = False
+    pretrained_model_name_or_path: str,
+    load_weights: bool = True,
+    add_pooling_layer: bool = False,
+    attn_implementation: Literal["flash_attention_2", "sdpa", "eager"] = "sdpa",
 ) -> BertBlocksModel:
     """Instantiate an equivalent BertBlocks model from pretrained HuggingFace BERT weights and config.
 
@@ -46,17 +51,25 @@ def from_huggingface_bert_model(
         - "BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding"
           (https://arxiv.org/abs/1810.04805)
     """
-    bertblocks_config = BertBlocksConfig.from_huggingface_bert(pretrained_model_name_or_path)
+    bertblocks_config = BertBlocksConfig.from_huggingface_bert(
+        pretrained_model_name_or_path, attn_implementation=attn_implementation
+    )
     bertblocks_model = BertBlocksModel(bertblocks_config, add_pooling_layer=add_pooling_layer)
 
     if load_weights:
         orig_model = BertModel.from_pretrained(pretrained_model_name_or_path, add_pooling_layer=add_pooling_layer)
-        bertblocks_model = from_bert_model(orig_model, add_pooling_layer=add_pooling_layer)
+        bertblocks_model = from_bert_model(
+            orig_model, add_pooling_layer=add_pooling_layer, attn_implementation=attn_implementation
+        )
 
     return bertblocks_model
 
 
-def from_bert_model(orig_model: BertModel, add_pooling_layer: bool = False) -> BertBlocksModel:
+def from_bert_model(
+    orig_model: BertModel,
+    add_pooling_layer: bool = False,
+    attn_implementation: Literal["flash_attention_2", "sdpa", "eager"] = "sdpa",
+) -> BertBlocksModel:
     """Instantiate an equivalent BertBlocks model from a HuggingFace BERT model instance.
 
     Converts a HuggingFace BERT model to BertBlocks architecture with weight transfer.
@@ -76,7 +89,7 @@ def from_bert_model(orig_model: BertModel, add_pooling_layer: bool = False) -> B
         - "BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding"
           (https://arxiv.org/abs/1810.04805)
     """
-    bertblocks_config = BertBlocksConfig.from_config(orig_model.config)
+    bertblocks_config = BertBlocksConfig.from_config(orig_model.config, attn_implementation=attn_implementation)
     bertblocks_model = BertBlocksModel(bertblocks_config, add_pooling_layer=add_pooling_layer)
 
     # Embedding layer

--- a/bertblocks/integration/load_modernbert.py
+++ b/bertblocks/integration/load_modernbert.py
@@ -36,23 +36,31 @@ def from_huggingface_modernbert_model(
 
     if load_weights:
         orig_model = ModernBertModel.from_pretrained(pretrained_model_name_or_path)
-        bertblocks_model = from_modernbert_model(orig_model, add_pooling_layer=add_pooling_layer)
+        bertblocks_model = from_modernbert_model(
+            orig_model, add_pooling_layer=add_pooling_layer, attn_implementation=attn_implementation
+        )
 
     return bertblocks_model
 
 
-def from_modernbert_model(orig_model: ModernBertModel, add_pooling_layer: bool = False) -> BertBlocksModel:
+def from_modernbert_model(
+    orig_model: ModernBertModel,
+    add_pooling_layer: bool = False,
+    attn_implementation: Literal["flash_attention_2", "sdpa", "eager"] = "sdpa",
+) -> BertBlocksModel:
     """Instantiate an equivalent BertBlocks model from a HuggingFace ModernBERT model instance.
 
     Args:
         orig_model: An instance of a HuggingFace ModernBertModel.
         add_pooling_layer (bool, optional): Whether to add a pooling layer. Defaults to False.
+        attn_implementation (str, optional): Attention backend. One of "flash_attention_2", "sdpa",
+            or "eager". Defaults to "sdpa".
 
     Returns:
         BertBlocksModel: A BertBlocks model with architecture matched to ModernBERT,
             loaded with pretrained weights.
     """
-    bertblocks_config = BertBlocksConfig.from_config(orig_model.config)
+    bertblocks_config = BertBlocksConfig.from_config(orig_model.config, attn_implementation=attn_implementation)
     bertblocks_model = BertBlocksModel(bertblocks_config, add_pooling_layer=add_pooling_layer)
 
     # Embedding layer

--- a/bertblocks/integration/load_modernbert.py
+++ b/bertblocks/integration/load_modernbert.py
@@ -29,18 +29,16 @@ def from_huggingface_modernbert_model(
     """
     from transformers import ModernBertModel
 
-    bertblocks_config = BertBlocksConfig.from_huggingface_modernbert(
-        pretrained_model_name_or_path, attn_implementation=attn_implementation
-    )
-    bertblocks_model = BertBlocksModel(bertblocks_config, add_pooling_layer=add_pooling_layer)
-
     if load_weights:
         orig_model = ModernBertModel.from_pretrained(pretrained_model_name_or_path)
-        bertblocks_model = from_modernbert_model(
+        return from_modernbert_model(
             orig_model, add_pooling_layer=add_pooling_layer, attn_implementation=attn_implementation
         )
 
-    return bertblocks_model
+    bertblocks_config = BertBlocksConfig.from_huggingface_modernbert(
+        pretrained_model_name_or_path, attn_implementation=attn_implementation
+    )
+    return BertBlocksModel(bertblocks_config, add_pooling_layer=add_pooling_layer)
 
 
 def from_modernbert_model(
@@ -97,8 +95,8 @@ def from_modernbert_model(
         if bertblocks_config.norm_bias:
             bertblocks_model.encd.blocks[i].pre_norm_ffwd.bias.data.copy_(orig_model.layers[i].mlp_norm.bias.data)
 
-        bertblocks_model.norm.weight.data.copy_(orig_model.final_norm.weight.data)
-        if bertblocks_config.norm_bias:
-            bertblocks_model.norm.bias.data.copy_(orig_model.final_norm.bias.data)
+    bertblocks_model.norm.weight.data.copy_(orig_model.final_norm.weight.data)
+    if bertblocks_config.norm_bias:
+        bertblocks_model.norm.bias.data.copy_(orig_model.final_norm.bias.data)
 
     return bertblocks_model

--- a/bertblocks/integration/load_modernbert.py
+++ b/bertblocks/integration/load_modernbert.py
@@ -1,111 +1,96 @@
 from typing import Literal
 
-from bertblocks.config import ModernBertConfig
+from transformers import ModernBertModel
+
+from bertblocks.config import BertBlocksConfig
 from bertblocks.modeling.model import BertBlocksModel
 
 
-def from_modernbert_model(
+def from_huggingface_modernbert_model(
     pretrained_model_name_or_path: str,
     load_weights: bool = True,
     add_pooling_layer: bool = False,
-    attn_implementation: Literal["flash_attention_2", "sdpa", "eager"] = "flash_attention_2",
-) -> "BertBlocksModel":
+    attn_implementation: Literal["flash_attention_2", "sdpa", "eager"] = "sdpa",
+) -> BertBlocksModel:
     """Instantiate an equivalent BertBlocks model from pretrained HuggingFace ModernBERT weights and config.
-
-    Converts a HuggingFace ModernBERT model to BertBlocks architecture with optional weight transfer.
-    ModernBERT uses ALiBi positional encodings, GLU feed-forward layers, and supports local attention,
-    which are all supported by BertBlocks.
 
     Args:
         pretrained_model_name_or_path (str): HuggingFace model identifier or local path to a
             pretrained ModernBERT model (e.g., "modernbert-base", "./path/to/model").
         load_weights (bool, optional): Whether to transfer weights from the pretrained ModernBERT model.
-            If True, copies all embeddings, attention, feed-forward, and normalization layer weights.
-            If False, only loads the configuration and initializes a fresh model. Defaults to True.
-        add_pooling_layer (bool, optional): Whether to add a pooling layer that processes the
-            [CLS] token. Useful for sequence-level classification tasks. Defaults to False.
+            Defaults to True.
+        add_pooling_layer (bool, optional): Whether to add a pooling layer. Defaults to False.
         attn_implementation (Literal["flash_attention_2", "sdpa", "eager"], optional):
-            Attention implementation backend to use:
-            - "flash_attention_2": Use FlashAttention-2 for faster inference (requires flash-attn package)
-            - "sdpa": Use PyTorch's scaled-dot-product attention (default, recommended for most cases)
-            - "eager": Use manual attention implementation (slower, for compatibility)
-            Defaults to "flash_attention_2".
+            Attention implementation backend. Defaults to "sdpa".
 
     Returns:
         BertBlocksModel: A BertBlocks model with architecture matched to ModernBERT, optionally
             loaded with pretrained weights.
-
-    Raises:
-        ValueError: If the model config cannot be loaded or if the model type is not ModernBERT.
-        OSError: If the model path does not exist or is not accessible.
-
-    Note:
-        - The weight transfer is exact and lossless; no approximation is used.
-        - All layer parameters (embeddings, QKV projections, GLU layers, norms) are copied directly.
-        - The pooling layer (if added) is initialized with new random weights.
-        - Final normalization layer weights are transferred if included in the model.
-
-    Example:
-        >>> from bertblocks.integration import from_modernbert_model
-        >>> # Load and convert a pretrained ModernBERT model with FlashAttention
-        >>> model = from_modernbert_model("modernbert-base", load_weights=True)
-        >>> # Load with SDPA backend for broader compatibility
-        >>> model = from_modernbert_model("modernbert-base", attn_implementation="sdpa")
-
-    References:
-        - "Smashing Language Barriers with Multilingual Transformers"
-          (https://arxiv.org/abs/2406.07581)
-        - "ModernBERT" (https://github.com/AnswerDotAI/ModernBERT)
     """
     from transformers import ModernBertModel
 
-    bertblocks_config = ModernBertConfig.from_huggingface(
+    bertblocks_config = BertBlocksConfig.from_huggingface_modernbert(
         pretrained_model_name_or_path, attn_implementation=attn_implementation
     )
     bertblocks_model = BertBlocksModel(bertblocks_config, add_pooling_layer=add_pooling_layer)
 
     if load_weights:
         orig_model = ModernBertModel.from_pretrained(pretrained_model_name_or_path)
-        # Embedding layer
-        bertblocks_model.embd.embd.weight.data.copy_(orig_model.embeddings.tok_embeddings.weight.data)
+        bertblocks_model = from_modernbert_model(orig_model, add_pooling_layer=add_pooling_layer)
 
-        for i in range(len(bertblocks_model.encd.blocks)):
-            # QKV Projection
-            bertblocks_model.encd.blocks[i].attn.proj.weight.data.copy_(orig_model.layers[i].attn.Wqkv.weight.data)
-            if bertblocks_config.attn_proj_bias:
-                bertblocks_model.encd.blocks[i].attn.proj.bias.data.copy_(orig_model.layers[i].attn.Wqkv.bias.data)
-            # Attention output projection
-            bertblocks_model.encd.blocks[i].attn.ffwd.weight.data.copy_(orig_model.layers[i].attn.Wo.weight.data)
-            if bertblocks_config.attn_out_bias:
-                bertblocks_model.encd.blocks[i].attn.ffwd.bias.data.copy_(orig_model.layers[i].attn.Wo.bias.data)
-            # Feed-forward up and down projection
-            bertblocks_model.encd.blocks[i].ffwd.uprj.weight.data.copy_(orig_model.layers[i].mlp.Wi.weight.data)
-            if bertblocks_config.mlp_in_bias:
-                bertblocks_model.encd.blocks[i].ffwd.uprj.bias.data.copy_(orig_model.layers[i].mlp.Wi.bias.data)
-            bertblocks_model.encd.blocks[i].ffwd.dprj.weight.data.copy_(orig_model.layers[i].mlp.Wo.weight.data)
-            if bertblocks_config.mlp_out_bias:
-                bertblocks_model.encd.blocks[i].ffwd.dprj.bias.data.copy_(orig_model.layers[i].mlp.Wo.bias.data)
-            # Norms
-            if i == 0:
-                # If first layer, the norm is in the embedding (pre-norm)
-                bertblocks_model.encd.blocks[i].pre_norm_attn.weight.data.copy_(orig_model.embeddings.norm.weight.data)
-                if bertblocks_config.norm_bias:
-                    bertblocks_model.encd.blocks[i].pre_norm_attn.bias.data.copy_(orig_model.embeddings.norm.bias.data)
-            else:
-                bertblocks_model.encd.blocks[i].pre_norm_attn.weight.data.copy_(
-                    orig_model.layers[i].attn_norm.weight.data
-                )
-                if bertblocks_config.norm_bias:
-                    bertblocks_model.encd.blocks[i].pre_norm_attn.bias.data.copy_(
-                        orig_model.layers[i].attn_norm.bias.data
-                    )
+    return bertblocks_model
 
-            bertblocks_model.encd.blocks[i].pre_norm_ffwd.weight.data.copy_(orig_model.layers[i].mlp_norm.weight.data)
+
+def from_modernbert_model(orig_model: ModernBertModel, add_pooling_layer: bool = False) -> BertBlocksModel:
+    """Instantiate an equivalent BertBlocks model from a HuggingFace ModernBERT model instance.
+
+    Args:
+        orig_model: An instance of a HuggingFace ModernBertModel.
+        add_pooling_layer (bool, optional): Whether to add a pooling layer. Defaults to False.
+
+    Returns:
+        BertBlocksModel: A BertBlocks model with architecture matched to ModernBERT,
+            loaded with pretrained weights.
+    """
+    bertblocks_config = BertBlocksConfig.from_config(orig_model.config)
+    bertblocks_model = BertBlocksModel(bertblocks_config, add_pooling_layer=add_pooling_layer)
+
+    # Embedding layer
+    bertblocks_model.embd.embd.weight.data.copy_(orig_model.embeddings.tok_embeddings.weight.data)
+
+    for i in range(len(bertblocks_model.encd.blocks)):
+        # QKV Projection
+        bertblocks_model.encd.blocks[i].attn.proj.weight.data.copy_(orig_model.layers[i].attn.Wqkv.weight.data)
+        if bertblocks_config.attn_proj_bias:
+            bertblocks_model.encd.blocks[i].attn.proj.bias.data.copy_(orig_model.layers[i].attn.Wqkv.bias.data)
+        # Attention output projection
+        bertblocks_model.encd.blocks[i].attn.ffwd.weight.data.copy_(orig_model.layers[i].attn.Wo.weight.data)
+        if bertblocks_config.attn_out_bias:
+            bertblocks_model.encd.blocks[i].attn.ffwd.bias.data.copy_(orig_model.layers[i].attn.Wo.bias.data)
+        # Feed-forward up and down projection
+        bertblocks_model.encd.blocks[i].ffwd.uprj.weight.data.copy_(orig_model.layers[i].mlp.Wi.weight.data)
+        if bertblocks_config.mlp_in_bias:
+            bertblocks_model.encd.blocks[i].ffwd.uprj.bias.data.copy_(orig_model.layers[i].mlp.Wi.bias.data)
+        bertblocks_model.encd.blocks[i].ffwd.dprj.weight.data.copy_(orig_model.layers[i].mlp.Wo.weight.data)
+        if bertblocks_config.mlp_out_bias:
+            bertblocks_model.encd.blocks[i].ffwd.dprj.bias.data.copy_(orig_model.layers[i].mlp.Wo.bias.data)
+        # Norms
+        if i == 0:
+            # If first layer, the norm is in the embedding (pre-norm)
+            bertblocks_model.encd.blocks[i].pre_norm_attn.weight.data.copy_(orig_model.embeddings.norm.weight.data)
             if bertblocks_config.norm_bias:
-                bertblocks_model.encd.blocks[i].pre_norm_ffwd.bias.data.copy_(orig_model.layers[i].mlp_norm.bias.data)
-
-            bertblocks_model.norm.weight.data.copy_(orig_model.final_norm.weight.data)
+                bertblocks_model.encd.blocks[i].pre_norm_attn.bias.data.copy_(orig_model.embeddings.norm.bias.data)
+        else:
+            bertblocks_model.encd.blocks[i].pre_norm_attn.weight.data.copy_(orig_model.layers[i].attn_norm.weight.data)
             if bertblocks_config.norm_bias:
-                bertblocks_model.norm.bias.data.copy_(orig_model.final_norm.bias.data)
+                bertblocks_model.encd.blocks[i].pre_norm_attn.bias.data.copy_(orig_model.layers[i].attn_norm.bias.data)
+
+        bertblocks_model.encd.blocks[i].pre_norm_ffwd.weight.data.copy_(orig_model.layers[i].mlp_norm.weight.data)
+        if bertblocks_config.norm_bias:
+            bertblocks_model.encd.blocks[i].pre_norm_ffwd.bias.data.copy_(orig_model.layers[i].mlp_norm.bias.data)
+
+        bertblocks_model.norm.weight.data.copy_(orig_model.final_norm.weight.data)
+        if bertblocks_config.norm_bias:
+            bertblocks_model.norm.bias.data.copy_(orig_model.final_norm.bias.data)
 
     return bertblocks_model

--- a/bertblocks/modeling/position.py
+++ b/bertblocks/modeling/position.py
@@ -48,7 +48,7 @@ if is_flash_attn_2_available():
         return dx, None, None, None, None, None, None
 
     def apply_rotary_setup_context(ctx, inputs, output):  # type: ignore
-        _, cos, sin, interleaved, cu_seqlens, max_seqlen, _ = inputs
+        x, cos, sin, interleaved, cu_seqlens, max_seqlen, attention_mask = inputs
         ctx.save_for_backward(cos, sin, cu_seqlens)
         ctx.interleaved = interleaved
         ctx.max_seqlen = max_seqlen

--- a/bertblocks/modeling/position.py
+++ b/bertblocks/modeling/position.py
@@ -48,7 +48,7 @@ if is_flash_attn_2_available():
         return dx, None, None, None, None, None, None
 
     def apply_rotary_setup_context(ctx, inputs, output):  # type: ignore
-        x, cos, sin, interleaved, cu_seqlens, max_seqlen, attention_mask = inputs
+        _, cos, sin, interleaved, cu_seqlens, max_seqlen, _ = inputs
         ctx.save_for_backward(cos, sin, cu_seqlens)
         ctx.interleaved = interleaved
         ctx.max_seqlen = max_seqlen

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -10,10 +10,10 @@
 
 ## Preset Configurations
 
-### BertConfig
+### BertBlocksConfig
 
 ```{eval-rst}
-.. autoclass:: bertblocks.config.BertConfig
+.. autoclass:: bertblocks.config.BertBlocksConfig
    :members:
    :show-inheritance:
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,7 +67,7 @@ Reproduces the original BERT architecture:
 from bertblocks.config import BertBlocksConfig
 from transformers import BertConfig
 
-config = BertBlocksConfig.from_config(BertConfig())
+config = BertBlocksConfig.from_config(BertConfig.from_pretrained("bert-base-uncased"))
 ```
 
 You can also create a `BertBlocksConfig` from a HuggingFace model:
@@ -84,7 +84,7 @@ Reproduces the ModernBERT architecture:
 from bertblocks.config import BertBlocksConfig
 from transformers import ModernBertConfig
 
-config = BertBlocksConfig.from_config(ModernBertConfig(vocab_size=50368))
+config = BertBlocksConfig.from_config(ModernBertConfig.from_pretrained("answerdotai/ModernBERT-base"))
 ```
 
 ```python

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,20 +59,21 @@ API reference for the full list.
 
 BertBlocks includes preset configurations that reproduce known architectures:
 
-### BertConfig
+### BertBlocksConfig
 
 Reproduces the original BERT architecture:
 
 ```python
-from bertblocks.config import BertConfig
+from bertblocks.config import BertBlocksConfig
+from transformers import BertConfig
 
-config = BertConfig(vocab_size=30522)
+config = BertBlocksConfig.from_config(BertConfig())
 ```
 
-You can also create a `BertConfig` from a HuggingFace model:
+You can also create a `BertBlocksConfig` from a HuggingFace model:
 
 ```python
-config = BertConfig.from_huggingface("bert-base-uncased")
+config = BertBlocksConfig.from_huggingface("bert-base-uncased")
 ```
 
 ### ModernBertConfig
@@ -80,13 +81,14 @@ config = BertConfig.from_huggingface("bert-base-uncased")
 Reproduces the ModernBERT architecture:
 
 ```python
-from bertblocks.config import ModernBertConfig
+from bertblocks.config import BertBlocksConfig
+from transformers import ModernBertConfig
 
-config = ModernBertConfig(vocab_size=50368)
+config = BertBlocksConfig.from_config(ModernBertConfig(vocab_size=50368))
 ```
 
 ```python
-config = ModernBertConfig.from_huggingface("answerdotai/ModernBERT-base")
+config = BertBlocksConfig.from_huggingface("answerdotai/ModernBERT-base")
 ```
 
 ## Validation

--- a/tests/integration/test_load_bert.py
+++ b/tests/integration/test_load_bert.py
@@ -175,7 +175,7 @@ class TestFromBertModel:
     @pytest.mark.dependency
     def test_attn(self, request, baseline_model_name, subtests, seq, hf_model, bb_model):  # type: ignore
         """Test the attention mechanism individually."""
-        # depends(request, [f"TestFromBertModel::test_embedding[{baseline_model_name}]"])
+        depends(request, [f"TestFromBertModel::test_embedding[{baseline_model_name}]"])
 
         from transformers.modeling_attn_mask_utils import _prepare_4d_attention_mask_for_sdpa
 
@@ -200,19 +200,19 @@ class TestFromBertModel:
     @pytest.mark.dependency
     def test_blocks(self, request, baseline_model_name, subtests, seq, hf_model, bb_model):  # type: ignore
         """Test the encoder blocks individually."""
-        # depends(
-        #     request,
-        #     [
-        #         f"TestFromBertModel::test_ffwd[{baseline_model_name}]",
-        #         f"TestFromBertModel::test_attn[{baseline_model_name}]",
-        #     ],
-        # )
+        depends(
+            request,
+            [
+                f"TestFromBertModel::test_ffwd[{baseline_model_name}]",
+                f"TestFromBertModel::test_attn[{baseline_model_name}]",
+            ],
+        )
 
         from transformers.masking_utils import create_bidirectional_mask
 
         hf_emb = hf_model.embeddings(seq["input_ids"])
         hf_attention_mask = create_bidirectional_mask(
-            config=bb_model.config, inputs_embeds=hf_emb, attention_mask=seq["attention_mask"]
+            config=hf_model.config, inputs_embeds=hf_emb, attention_mask=seq["attention_mask"]
         )
         bb_emb = bb_model.embd(seq["input_ids"])
         bb_attention_mask = create_bidirectional_mask(

--- a/tests/integration/test_load_bert.py
+++ b/tests/integration/test_load_bert.py
@@ -3,7 +3,7 @@ import torch
 from pytest_dependency import depends
 from transformers import AutoTokenizer, BertModel
 
-from bertblocks.integration import from_bert_model
+from bertblocks.integration import from_huggingface
 
 TEST_MODELS = ["bert-base-uncased", "bert-base-cased", "bert-large-uncased"]
 
@@ -30,7 +30,7 @@ class TestFromBertModel:
     @pytest.fixture(scope="class")
     def bb_model(self, baseline_model):  # type: ignore
         """Instantiate BertBlocks model as fixture."""
-        bb_model = from_bert_model(baseline_model, add_pooling_layer=False).to(self.device)
+        bb_model = from_huggingface(baseline_model, add_pooling_layer=False).to(self.device)
         bb_model.eval()
         yield bb_model
         del bb_model
@@ -200,30 +200,33 @@ class TestFromBertModel:
     @pytest.mark.dependency
     def test_blocks(self, request, baseline_model_name, subtests, seq, hf_model, bb_model):  # type: ignore
         """Test the encoder blocks individually."""
-        depends(
-            request,
-            [
-                f"TestFromBertModel::test_ffwd[{baseline_model_name}]",
-                f"TestFromBertModel::test_attn[{baseline_model_name}]",
-            ],
-        )
+        # depends(
+        #     request,
+        #     [
+        #         f"TestFromBertModel::test_ffwd[{baseline_model_name}]",
+        #         f"TestFromBertModel::test_attn[{baseline_model_name}]",
+        #     ],
+        # )
 
-        from transformers.modeling_attn_mask_utils import _prepare_4d_attention_mask_for_sdpa
+        from transformers.masking_utils import create_bidirectional_mask
 
-        bb_emb = bb_model.embd(seq["input_ids"])
         hf_emb = hf_model.embeddings(seq["input_ids"])
-        attention_mask = _prepare_4d_attention_mask_for_sdpa(
-            seq["attention_mask"], dtype=hf_emb.dtype, tgt_len=seq["input_ids"].shape[1]
+        hf_attention_mask = create_bidirectional_mask(
+            config=bb_model.config, inputs_embeds=hf_emb, attention_mask=seq["attention_mask"]
+        )
+        bb_emb = bb_model.embd(seq["input_ids"])
+        bb_attention_mask = create_bidirectional_mask(
+            config=bb_model.config, inputs_embeds=bb_emb, attention_mask=seq["attention_mask"]
         )
 
         with torch.no_grad():
             for layer_idx in range(len(hf_model.encoder.layer)):
                 with subtests.test(f"layer_{layer_idx}"):
                     torch.testing.assert_close(
-                        hf_model.encoder.layer[layer_idx](hf_emb, attention_mask=attention_mask)[0][
+                        hf_model.encoder.layer[layer_idx](hf_emb, attention_mask=hf_attention_mask)[
                             seq["attention_mask"].bool()
                         ],
-                        bb_model.encd.blocks[layer_idx](bb_emb, attention_mask=attention_mask)[0][
+                        bb_model.encd.blocks[layer_idx](bb_emb, attention_mask=bb_attention_mask)[0][
                             seq["attention_mask"].bool()
                         ],
                     )

--- a/tests/integration/test_load_modernbert.py
+++ b/tests/integration/test_load_modernbert.py
@@ -2,14 +2,15 @@ import pytest
 import torch
 from pytest_dependency import depends
 from transformers import AutoTokenizer, ModernBertConfig, ModernBertModel
+from transformers.masking_utils import create_bidirectional_mask
 
-from bertblocks.integration import from_modernbert_model
+from bertblocks.integration import from_huggingface
 from bertblocks.modeling.padding import pad_output
 
 TEST_MODELS = ["answerdotai/ModernBERT-base", "answerdotai/ModernBERT-large"]
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available but flash-attn depends on it")
+# @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available but flash-attn depends on it")
 @pytest.mark.parametrize("baseline_model", TEST_MODELS, scope="class")
 class TestFromModernBertModel:
     """Test equivalency of Huggingface ModernBERT and loaded BertBlocks implementations."""
@@ -35,7 +36,7 @@ class TestFromModernBertModel:
     @pytest.fixture(scope="class")
     def bb_model(self, baseline_model):  # type: ignore
         """Instantiate bertblocks model as fixture."""
-        bertblocks_model = from_modernbert_model(baseline_model, add_pooling_layer=False).to(self.device)
+        bertblocks_model = from_huggingface(baseline_model, add_pooling_layer=False).to(self.device)
         bertblocks_model.eval()
         yield bertblocks_model
         del bertblocks_model
@@ -53,7 +54,7 @@ class TestFromModernBertModel:
                 "Wow, that's an incredibly fast response!",
             ],
             return_tensors="pt",
-            padding="max_length",
+            padding=True,
         ).to(self.device)
         del tokenizer
 
@@ -156,19 +157,30 @@ class TestFromModernBertModel:
             ],
         )
 
-        from bertblocks.modeling.padding import unpad_input
-
         with torch.no_grad():
-            input_ids, _, cu_seqlens, max_seq_len = unpad_input(seq["input_ids"], seq["attention_mask"])
+            input_ids = seq["input_ids"]
+            attention_mask = seq["attention_mask"]
 
             hf_emb = hf_model.embeddings(input_ids)
+            position_ids = torch.arange(input_ids.shape[1], device=input_ids.device).unsqueeze(0).expand_as(input_ids)
+            hf_attention_mask = create_bidirectional_mask(
+                config=hf_model.config, inputs_embeds=hf_emb, attention_mask=seq["attention_mask"]
+            )
             bb_emb = bb_model.encd.blocks[0].pre_norm_attn(bb_model.embd(input_ids))
+            bb_attention_mask = create_bidirectional_mask(
+                config=bb_model.config, inputs_embeds=bb_emb, attention_mask=seq["attention_mask"]
+            )
 
             for layer_idx in range(len(hf_model.layers)):
+                position_embeddings = hf_model.rotary_emb(hf_emb, position_ids, hf_model.config.layer_types[layer_idx])
                 with subtests.test(f"layer_{layer_idx}"):
                     torch.testing.assert_close(
-                        hf_model.layers[layer_idx].attn(hf_emb, cu_seqlens=cu_seqlens, max_seqlen=max_seq_len)[0],
-                        bb_model.encd.blocks[layer_idx].attn(bb_emb, cu_seqlens=cu_seqlens, max_seq_len=max_seq_len)[0],
+                        hf_model.layers[layer_idx].attn(hf_emb, position_embeddings, hf_attention_mask)[0][
+                            attention_mask.bool()
+                        ],
+                        bb_model.encd.blocks[layer_idx].attn(bb_emb, attention_mask=bb_attention_mask)[0][
+                            attention_mask.bool()
+                        ],
                     )
 
     @pytest.mark.dependency
@@ -225,27 +237,46 @@ class TestFromModernBertModel:
             ],
         )
 
-        from bertblocks.modeling.padding import unpad_input
-
         with torch.no_grad():
-            input_ids, _, cu_seqlens, max_seq_len = unpad_input(seq["input_ids"], seq["attention_mask"])
+            input_ids, attention_mask = seq["input_ids"], seq["attention_mask"]
 
             hf_emb = hf_model.embeddings(input_ids)
             bb_emb = bb_model.encd.blocks[0].pre_norm_attn(bb_model.embd(input_ids))
 
+            hf_emb = hf_model.embeddings(input_ids)
+            position_ids = torch.arange(input_ids.shape[1], device=input_ids.device).unsqueeze(0).expand_as(input_ids)
+            hf_attention_mask = create_bidirectional_mask(
+                config=hf_model.config, inputs_embeds=hf_emb, attention_mask=attention_mask
+            )
+            bb_emb = bb_model.encd.blocks[0].pre_norm_attn(bb_model.embd(input_ids))
+            bb_attention_mask = create_bidirectional_mask(
+                config=bb_model.config, inputs_embeds=bb_emb, attention_mask=attention_mask
+            )
+
             for layer_idx in range(len(hf_model.layers)):
+                position_embeddings = hf_model.rotary_emb(hf_emb, position_ids, hf_model.config.layer_types[layer_idx])
                 with subtests.test(f"layer_{layer_idx}"):
                     if layer_idx == 0:
                         torch.testing.assert_close(
                             hf_model.layers[layer_idx](
-                                hf_model.embeddings.norm(hf_emb), cu_seqlens=cu_seqlens, max_seqlen=max_seq_len
-                            )[0],
-                            bb_model.encd.blocks[layer_idx](bb_emb, cu_seqlens=cu_seqlens, max_seq_len=max_seq_len)[0],
+                                hf_model.embeddings.norm(hf_emb),
+                                attention_mask=hf_attention_mask,
+                                position_embeddings=position_embeddings,
+                            )[attention_mask.bool()],
+                            bb_model.encd.blocks[layer_idx](bb_emb, attention_mask=bb_attention_mask)[0][
+                                attention_mask.bool()
+                            ],
                         )
                     else:
                         torch.testing.assert_close(
-                            hf_model.layers[layer_idx](hf_emb, cu_seqlens=cu_seqlens, max_seqlen=max_seq_len)[0],
-                            bb_model.encd.blocks[layer_idx](bb_emb, cu_seqlens=cu_seqlens, max_seq_len=max_seq_len)[0],
+                            hf_model.layers[layer_idx](
+                                hf_emb,
+                                attention_mask=hf_attention_mask,
+                                position_embeddings=position_embeddings,
+                            )[attention_mask.bool()],
+                            bb_model.encd.blocks[layer_idx](bb_emb, attention_mask=bb_attention_mask)[0][
+                                attention_mask.bool()
+                            ],
                         )
 
     @pytest.mark.dependency
@@ -261,5 +292,4 @@ class TestFromModernBertModel:
         with torch.no_grad():
             hf_out = hf_model.forward(seq["input_ids"], attention_mask=seq["attention_mask"]).last_hidden_state
             bb_out = bb_model.forward(seq["input_ids"], attention_mask=seq["attention_mask"])
-            bb_out = pad_output(bb_out.last_hidden_state, bb_out.indices, hf_out.shape[0], hf_out.shape[1])
-            torch.testing.assert_close(hf_out, bb_out)
+            torch.testing.assert_close(hf_out[seq["attention_mask"].bool()], bb_out[0][seq["attention_mask"].bool()])


### PR DESCRIPTION
This PR attempts to cleanup the model loading functionality.

1. Removes `BertConfig` and `ModernBertConfig` and just keeps the `BertBlocksConfig`
2. Adds `from_model` (convert an in-memory model into a bertblocks model) and `from_huggingface` (convert a pre-trained checkpoint into a bertblocks model) functions 