### PR TITLE
Allow only local attention

### DIFF
--- a/bertblocks/config/__init__.py
+++ b/bertblocks/config/__init__.py
@@ -79,7 +79,8 @@ class BertBlocksConfig(PreTrainedConfig):
         attn_proj_bias: Whether to include bias terms in the qkv projection of attention layers.
         attn_out_bias: Whether to include bias terms in the output projection of attention layers.
         local_attention: Whether to include local attention mechanism. Default (-1, -1) means global attention.
-        global_attention_every_n_layers: The layer step size for global attention.
+        global_attention_every_n_layers: The layer step size for global attention. Set to 0 to disable global attention.
+            Set to 1 for global attention in every layer. Set to 2 for global attention in every other layer, etc.
         initializer_kind: The initialization method for weights. Determines the type of
             distribution random weights are sampled from for initialization.
             Defaults to a truncated normal distribution.
@@ -148,7 +149,7 @@ class BertBlocksConfig(PreTrainedConfig):
         num_blocks: int = 12,
         attn_implementation: AttentionBackend | None = None,
         local_attention: tuple[int, int] = (-1, -1),
-        global_attention_every_n_layers: int = 0,
+        global_attention_every_n_layers: int = 1,
         initializer_kind: Initializer = "trunc_normal",
         initializer_range: float = 0.02,
         initializer_cutoff_factor: float = 3.0,

--- a/bertblocks/modeling/attention.py
+++ b/bertblocks/modeling/attention.py
@@ -52,12 +52,12 @@ class Attention(nn.Module):
         self.head_dim = self.hidden_size // self.num_heads
         self.max_seq_len = config.max_sequence_length
         self.dropout_p = config.attn_dropout_prob
-        if config.global_attention_every_n_layers != 0:
-            self.local_attention = (
-                config.local_attention if layer_id % config.global_attention_every_n_layers != 0 else (-1, -1)
-            )
+        if config.global_attention_every_n_layers == 0:
+            self.local_attention = config.local_attention
         else:
-            self.local_attention = (-1, -1)
+            self.local_attention = (
+                (-1, -1) if layer_id % config.global_attention_every_n_layers == 0 else config.local_attention
+            )
         self.deterministic = True
         # Layers
         self.norm_qk = config.norm_qk

--- a/configs/baselines/pretraining-bert-base.yaml
+++ b/configs/baselines/pretraining-bert-base.yaml
@@ -40,7 +40,7 @@ model:
       attn_dropout_prob: 0.1
       classifier_dropout: 0.0
       emb_dropout_prob: 0.1
-      global_attention_every_n_layers: 0
+      global_attention_every_n_layers: 1
       hidden_dropout_prob: 0.1
       pad_token_id: 0
       head_type: "proj"


### PR DESCRIPTION
This PR changes the semantics of the `global_attention_every_n_layers` option by allowing `0` to mean only local attention. `1` is then only global attention.
