### PR TITLE
Move local attention mask to attention backend

### DIFF
--- a/bertblocks/modeling/attention.py
+++ b/bertblocks/modeling/attention.py
@@ -214,6 +214,15 @@ class Attention(nn.Module):
                 deterministic=self.deterministic,
             )
         elif attention_mask is not None:
+            if self.local_attention != (-1, -1) and self.local_attention[0] > 0:
+                window_size = self.local_attention[0]
+                pos = torch.arange(x.shape[1], device=x.device)
+                local_mask = (pos.unsqueeze(0) - pos.unsqueeze(1)).abs() <= window_size
+                if attention_mask.dtype == torch.bool:
+                    attention_mask = attention_mask & local_mask
+                else:
+                    attention_mask = attention_mask.masked_fill(~local_mask, -float("inf"))
+
             x_out, w = self._backend.forward_padded(
                 q,
                 k,

--- a/bertblocks/modeling/model.py
+++ b/bertblocks/modeling/model.py
@@ -308,15 +308,6 @@ class BertBlocksModel(BertBlocksPreTrainedModel):
             if self.config.block_pos_enc_kind == "alibi" and self.alibi is not None:
                 attention_mask = self.alibi(attention_mask)
 
-            if self.local_attention != (-1, -1) and self.local_attention[0] > 0:
-                window_size = self.local_attention[0]
-                pos = torch.arange(input_ids.shape[1], device=input_ids.device)
-                local_mask = (pos.unsqueeze(0) - pos.unsqueeze(1)).abs() <= window_size
-                if attention_mask.dtype == torch.bool:
-                    attention_mask = attention_mask & local_mask
-                else:
-                    attention_mask = attention_mask.masked_fill(~local_mask, -float("inf"))
-
         x, pooler_output, hidden_states, attentions = self._forward(
             input_ids,
             attention_mask,


### PR DESCRIPTION
If local attention was set to only some layers and non-flash attention was used, the local attention mask was computed once and applied to all layers. Therefore, local attention was applied in every layer, even though it should only be applied in a some.
