### PR TITLE
Add pad_output flag

### DIFF
--- a/bertblocks/modeling/model.py
+++ b/bertblocks/modeling/model.py
@@ -36,7 +36,7 @@ from bertblocks.modeling.position import AlibiPositionalEncoding
 
 
 @dataclass
-class MaybeUnpaddedBaseModelOutput(BaseModelOutput):
+class UnpaddedBaseModelOutput(BaseModelOutput):
     cu_seqlens: torch.FloatTensor | None = None
     indices: torch.FloatTensor | None = None
     seq_len: int | None = None
@@ -44,7 +44,7 @@ class MaybeUnpaddedBaseModelOutput(BaseModelOutput):
 
 
 @dataclass
-class MaybeUnpaddedBaseModelOutputWithPooling(BaseModelOutputWithPooling):
+class UnpaddedBaseModelOutputWithPooling(BaseModelOutputWithPooling):
     cu_seqlens: torch.FloatTensor | None = None
     indices: torch.FloatTensor | None = None
     seq_len: int | None = None
@@ -165,6 +165,42 @@ class BertBlocksPreTrainedModel(PreTrainedModel):
         if hasattr(module, "gradient_checkpointing"):
             module.gradient_checkpointing = value
 
+    def pad_output(
+        self, output: UnpaddedBaseModelOutput | UnpaddedBaseModelOutputWithPooling
+    ) -> BaseModelOutput | BaseModelOutputWithPooling:
+        indices = output.indices
+        seq_len = output.seq_len or 0
+        batch_size = output.batch_size or 0
+
+        if indices is None:
+            return output
+
+        if isinstance(output, BaseModelOutputWithPooling):
+            return BaseModelOutputWithPooling(
+                last_hidden_state=pad_output(
+                    output.last_hidden_state, indices, batch_size, seq_len, self.model.pad_token_id
+                ),
+                pooler_output=output.pooler_output,
+                hidden_states=[
+                    pad_output(h, indices, batch_size, seq_len, self.pad_token_id) for h in output.hidden_states
+                ]
+                if output.hidden_states is not None
+                else None,
+                attentions=output.attentions,
+            )
+        else:
+            return BaseModelOutput(
+                last_hidden_state=pad_output(
+                    output.last_hidden_state, indices, batch_size, seq_len, self.model.pad_token_id
+                ),
+                hidden_states=[
+                    pad_output(h, indices, batch_size, seq_len, self.pad_token_id) for h in output.hidden_states
+                ]
+                if output.hidden_states is not None
+                else None,
+                attentions=output.attentions,
+            )
+
 
 class BertBlocksModel(BertBlocksPreTrainedModel):
     """Core BertBlocks model for encoding sequences.
@@ -267,7 +303,8 @@ class BertBlocksModel(BertBlocksPreTrainedModel):
         token_type_ids: "torch.Tensor | None" = None,
         output_attentions: "bool" = False,
         output_hidden_states: "bool" = False,
-    ) -> "MaybeUnpaddedBaseModelOutput | MaybeUnpaddedBaseModelOutputWithPooling":
+        pad_outputs: "bool" = True,
+    ) -> "UnpaddedBaseModelOutput | UnpaddedBaseModelOutputWithPooling | BaseModelOutput | BaseModelOutputWithPooling":
         """Forward pass of the BertBlocks model.
 
         Args:
@@ -278,6 +315,7 @@ class BertBlocksModel(BertBlocksPreTrainedModel):
                 of tokens. Defaults to None.
             output_attentions: Whether to return attention weights from all layers. Defaults to None.
             output_hidden_states: Whether to return hidden states from all layers. Defaults to False.
+            pad_outputs: Whether to pad outputs if model is in unpadding mode. Defaults to True.
 
         Returns:
             BaseModelOutput or BaseModelOutputWithPooling containing:
@@ -327,27 +365,25 @@ class BertBlocksModel(BertBlocksPreTrainedModel):
             output_hidden_states,
         )
 
+        outputs: dict[str, Any] = {"last_hidden_state": x}
         if pooler_output is not None:
-            return MaybeUnpaddedBaseModelOutputWithPooling(
-                last_hidden_state=x,
-                pooler_output=pooler_output,
-                hidden_states=hidden_states if output_hidden_states else None,
-                attentions=attentions if output_attentions else None,
-                cu_seqlens=cu_seqlens,
-                indices=indices,
-                seq_len=seq_len,
-                batch_size=batch_size,
-            )
+            outputs["pooler_output"] = pooler_output
+        if output_hidden_states:
+            outputs["hidden_states"] = hidden_states
+        if output_attentions:
+            outputs["attentions"] = attentions
+
+        if self.unpadding:
+            output_cls = UnpaddedBaseModelOutputWithPooling if pooler_output is not None else UnpaddedBaseModelOutput
+            outputs.update({"cu_seqlens": cu_seqlens, "indices": indices, "seq_len": seq_len, "batch_size": batch_size})
         else:
-            return MaybeUnpaddedBaseModelOutput(
-                last_hidden_state=x,
-                hidden_states=hidden_states if output_hidden_states else None,
-                attentions=attentions if output_attentions else None,
-                cu_seqlens=cu_seqlens,
-                indices=indices,
-                seq_len=seq_len,
-                batch_size=batch_size,
-            )
+            output_cls = BaseModelOutputWithPooling if pooler_output is not None else BaseModelOutput
+
+        output = output_cls(**outputs)
+        if pad_outputs and isinstance(output, (UnpaddedBaseModelOutput, UnpaddedBaseModelOutputWithPooling)):
+            output = self.pad_output(output)
+
+        return output
 
 
 class BertBlocksForTasksBase(BertBlocksPreTrainedModel):
@@ -366,42 +402,6 @@ class BertBlocksForTasksBase(BertBlocksPreTrainedModel):
         super().__init__(config, *args, **kwargs)
         self.model = BertBlocksModel(config)
         self.head = get_prediction_head(config)
-
-    def pad_output(
-        self, output: MaybeUnpaddedBaseModelOutput | MaybeUnpaddedBaseModelOutputWithPooling
-    ) -> BaseModelOutput | BaseModelOutputWithPooling:
-        indices = output.indices
-        seq_len = output.seq_len or 0
-        batch_size = output.batch_size or 0
-
-        if indices is None:
-            return output
-
-        if isinstance(output, BaseModelOutputWithPooling):
-            return BaseModelOutputWithPooling(
-                last_hidden_state=pad_output(
-                    output.last_hidden_state, indices, batch_size, seq_len, self.model.pad_token_id
-                ),
-                pooler_output=output.pooler_output,
-                hidden_states=[
-                    pad_output(h, indices, batch_size, seq_len, self.pad_token_id) for h in output.hidden_states
-                ]
-                if output.hidden_states is not None
-                else None,
-                attentions=output.attentions,
-            )
-        else:
-            return BaseModelOutput(
-                last_hidden_state=pad_output(
-                    output.last_hidden_state, indices, batch_size, seq_len, self.model.pad_token_id
-                ),
-                hidden_states=[
-                    pad_output(h, indices, batch_size, seq_len, self.pad_token_id) for h in output.hidden_states
-                ]
-                if output.hidden_states is not None
-                else None,
-                attentions=output.attentions,
-            )
 
     def compute_loss(
         self,
@@ -507,21 +507,24 @@ class BertBlocksForMaskedLM(BertBlocksPreTrainedModel):
                 - `attentions`: Attention weights from all layers if requested
 
         """
-        output: MaybeUnpaddedBaseModelOutput = self.model(
+        output = self.model(
             input_ids,
             attention_mask=attention_mask,
             token_type_ids=token_type_ids,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
+            pad_outputs=False,
         )
         logits = self.decoder(self.head(output.last_hidden_state))
 
         loss = None
         if labels is not None:
-            labels = labels.flatten()[output.indices] if output.indices is not None else labels.flatten()
+            labels = labels.flatten()
+            if isinstance(output, UnpaddedBaseModelOutput) and output.indices is not None:
+                labels = labels[output.indices]
             loss = self.loss_fn(logits.view(-1, self.vocab_size), labels)
 
-        if output.indices is not None:
+        if isinstance(output, UnpaddedBaseModelOutput) and output.indices is not None:
             indices = output.indices
             seq_len = output.seq_len or 0
             batch_size = output.batch_size or 0  # Just to satisfy mypy, this will never trigger in practice
@@ -529,19 +532,18 @@ class BertBlocksForMaskedLM(BertBlocksPreTrainedModel):
                 loss=loss,
                 logits=pad_output(logits, indices, batch_size, seq_len, -torch.inf),
                 hidden_states=[
-                    pad_output(h, indices, batch_size, seq_len, self.pad_token_id) for h in output.hidden_states
+                    pad_output(h, indices, batch_size, seq_len, self.model.pad_token_id) for h in output.hidden_states
                 ]
                 if output.hidden_states is not None
                 else None,
                 attentions=output.attentions,
             )
-        else:
-            return MaskedLMOutput(
-                loss=loss,
-                logits=logits,
-                hidden_states=output.hidden_states,
-                attentions=output.attentions,
-            )
+        return MaskedLMOutput(
+            loss=loss,
+            logits=logits,
+            hidden_states=output.hidden_states,
+            attentions=output.attentions,
+        )
 
 
 class BertBlocksForEnhancedMaskedLM(BertBlocksForMaskedLM):
@@ -609,7 +611,7 @@ class BertBlocksForEnhancedMaskedLM(BertBlocksForMaskedLM):
                 - `attentions`: Attention weights from all layers if requested
 
         """
-        output: MaybeUnpaddedBaseModelOutput = self.model(
+        output = self.model(
             input_ids,
             attention_mask=attention_mask,
             token_type_ids=token_type_ids,
@@ -621,30 +623,14 @@ class BertBlocksForEnhancedMaskedLM(BertBlocksForMaskedLM):
 
         loss = None
         if labels is not None:
-            labels = labels.flatten()[output.indices] if output.indices is not None else labels.flatten()
-            loss = self.loss_fn(logits.view(-1, self.vocab_size), labels)
+            loss = self.loss_fn(logits.view(-1, self.vocab_size), labels.flatten())
 
-        if output.indices is not None:
-            indices = output.indices
-            seq_len = output.seq_len or 0
-            batch_size = output.batch_size or 0
-            return MaskedLMOutput(
-                loss=loss,
-                logits=pad_output(logits, indices, batch_size, seq_len, -torch.inf),
-                hidden_states=[
-                    pad_output(h, indices, batch_size, seq_len, self.pad_token_id) for h in output.hidden_states
-                ]
-                if output.hidden_states is not None
-                else None,
-                attentions=output.attentions,
-            )
-        else:
-            return MaskedLMOutput(
-                loss=loss,
-                logits=logits,
-                hidden_states=output.hidden_states,
-                attentions=output.attentions,
-            )
+        return MaskedLMOutput(
+            loss=loss,
+            logits=logits,
+            hidden_states=output.hidden_states,
+            attentions=output.attentions,
+        )
 
 
 class BertBlocksForSequenceClassification(BertBlocksForTasksBase):
@@ -709,18 +695,33 @@ class BertBlocksForSequenceClassification(BertBlocksForTasksBase):
             token_type_ids=token_type_ids,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
+            pad_outputs=False,
         )
-        output = self.pad_output(output)
 
-        cls_features = output.last_hidden_state[:, 0, :]  # Regular CLS token extraction
+        if isinstance(output, UnpaddedBaseModelOutput) and output.cu_seqlens is not None:
+            # CLS token is the first token of each sequence; in the unpadded tensor its
+            # position is given by the sequence start indices: cu_seqlens[:-1].
+            cls_indices = output.cu_seqlens[:-1].long()
+            cls_features = output.last_hidden_state[cls_indices]
+            hidden_states = (
+                [
+                    pad_output(h, output.indices, output.batch_size or 0, output.seq_len or 0, self.model.pad_token_id)
+                    for h in output.hidden_states
+                ]
+                if output.hidden_states is not None
+                else None
+            )
+        else:
+            cls_features = output.last_hidden_state[:, 0, :]  # Regular CLS token extraction
+            hidden_states = output.hidden_states
+
         logits = self.classifier(self.head(cls_features))
-
         loss = self.compute_loss(logits, labels, self.problem_type)
 
         return SequenceClassifierOutput(
             loss=loss,
             logits=logits,
-            hidden_states=output.hidden_states,
+            hidden_states=hidden_states,
             attentions=output.attentions,
         )
 
@@ -787,12 +788,33 @@ class BertBlocksForTokenClassification(BertBlocksForTasksBase):
             token_type_ids=token_type_ids,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
+            pad_outputs=False,
         )
-        output = self.pad_output(output)
         logits = self.classifier(self.head(output.last_hidden_state))
 
-        loss = self.compute_loss(logits, labels, self.problem_type)
+        is_unpadded = isinstance(output, UnpaddedBaseModelOutput) and output.indices is not None
 
+        loss = None
+        if labels is not None:
+            flat_labels = labels.flatten()
+            if is_unpadded:
+                flat_labels = flat_labels[output.indices]
+            loss = self.loss_fn(logits.view(-1, self.num_classes), flat_labels)
+
+        if is_unpadded:
+            indices = output.indices
+            seq_len = output.seq_len or 0
+            batch_size = output.batch_size or 0
+            return TokenClassifierOutput(
+                loss=loss,
+                logits=pad_output(logits, indices, batch_size, seq_len, 0),
+                hidden_states=[
+                    pad_output(h, indices, batch_size, seq_len, self.model.pad_token_id) for h in output.hidden_states
+                ]
+                if output.hidden_states is not None
+                else None,
+                attentions=output.attentions,
+            )
         return TokenClassifierOutput(
             loss=loss,
             logits=logits,
@@ -863,9 +885,22 @@ class BertBlocksForQuestionAnswering(BertBlocksForTasksBase):
             token_type_ids=token_type_ids,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
+            pad_outputs=False,
         )
-        output = self.pad_output(output)
         logits = self.classifier(self.head(output.last_hidden_state))
+
+        if isinstance(output, UnpaddedBaseModelOutput) and output.indices is not None:
+            indices = output.indices
+            seq_len = output.seq_len or 0
+            batch_size = output.batch_size or 0
+            logits = pad_output(logits, indices, batch_size, seq_len, 0)
+            hidden_states = (
+                [pad_output(h, indices, batch_size, seq_len, self.model.pad_token_id) for h in output.hidden_states]
+                if output.hidden_states is not None
+                else None
+            )
+        else:
+            hidden_states = output.hidden_states
 
         start_logits, end_logits = logits.split(1, dim=-1)
         start_logits = start_logits.squeeze(-1).contiguous()
@@ -890,7 +925,7 @@ class BertBlocksForQuestionAnswering(BertBlocksForTasksBase):
             loss=loss,
             start_logits=start_logits,
             end_logits=end_logits,
-            hidden_states=output.hidden_states,
+            hidden_states=hidden_states,
             attentions=output.attentions,
         )
 
@@ -950,18 +985,20 @@ class BertBlocksForMaskedDiffusion(BertBlocksForMaskedLM, GenerationMixin):
         if attention_mask is None:
             attention_mask = torch.ones_like(input_ids)
 
-        output: MaybeUnpaddedBaseModelOutput = self.model(
+        output = self.model(
             input_ids,
             attention_mask=attention_mask,
             token_type_ids=token_type_ids,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
+            pad_outputs=False,
         )
         logits = self.decoder(self.head(output.last_hidden_state))
 
         if labels is not None:
             # Binary mask indicating unmasked tokens in batch (that should not contribute to the loss)
-            if output.indices is not None:
+            if isinstance(output, UnpaddedBaseModelOutput):
+                assert output.indices is not None, "Output indices should not be None in unpadding mode"
                 unpadded_input_ids = input_ids.flatten()[output.indices]
                 unpadded_labels = labels.flatten()[output.indices]
                 masked_labels = torch.where(unpadded_input_ids == self.mask_token_id, unpadded_labels, -100)
@@ -976,7 +1013,8 @@ class BertBlocksForMaskedDiffusion(BertBlocksForMaskedLM, GenerationMixin):
         else:
             loss = None
 
-        if output.indices is not None:
+        if isinstance(output, UnpaddedBaseModelOutput):
+            assert output.indices is not None, "Output indices should not be None in unpadding mode"
             indices = output.indices
             seq_len = output.seq_len or 0
             batch_size = output.batch_size or 0

--- a/tests/modeling/test_task_models.py
+++ b/tests/modeling/test_task_models.py
@@ -1,0 +1,461 @@
+"""Tests for task-specific BertBlocks model variants.
+
+Each variant is tested with both padded (standard) and unpadded (flash-attention-style)
+base model outputs by mocking the inner BertBlocksModel.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+from transformers.modeling_outputs import BaseModelOutput
+
+from bertblocks.config import BertBlocksConfig
+from bertblocks.modeling.model import (
+    BertBlocksForEnhancedMaskedLM,
+    BertBlocksForMaskedLM,
+    BertBlocksForQuestionAnswering,
+    BertBlocksForSequenceClassification,
+    BertBlocksForTokenClassification,
+    UnpaddedBaseModelOutput,
+)
+
+# ── Dimensions ──────────────────────────────────────────────────────────────
+BATCH = 2
+SEQ_LEN = 8
+HIDDEN = 32
+VOCAB = 100
+NUM_CLASSES = 4
+
+# Unpadded: last token of each sequence is treated as padding → 2 positions removed.
+TOTAL_TOKENS = BATCH * SEQ_LEN - 2
+# Flat indices of non-padding positions in the [BATCH * SEQ_LEN] tensor.
+_INDICES = torch.cat(
+    [
+        torch.arange(SEQ_LEN - 1),  # positions 0-6  (seq 0, length 7)
+        torch.arange(SEQ_LEN, BATCH * SEQ_LEN - 1),  # positions 8-14 (seq 1, length 7)
+    ]
+)  # shape [TOTAL_TOKENS]
+# Cumulative sequence lengths for flash-attention style indexing.
+# Seq 0: 7 tokens, seq 1: 7 tokens → [0, 7, 14].
+_CU_SEQLENS = torch.tensor([0, SEQ_LEN - 1, TOTAL_TOKENS], dtype=torch.int32)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _padded_base_output(hidden_states: bool = False) -> BaseModelOutput:
+    hs = tuple(torch.randn(BATCH, SEQ_LEN, HIDDEN) for _ in range(3)) if hidden_states else None
+    return BaseModelOutput(
+        last_hidden_state=torch.randn(BATCH, SEQ_LEN, HIDDEN),
+        hidden_states=hs,
+        attentions=None,
+    )
+
+
+def _unpadded_base_output(hidden_states: bool = False) -> UnpaddedBaseModelOutput:
+    hs = tuple(torch.randn(TOTAL_TOKENS, HIDDEN) for _ in range(3)) if hidden_states else None
+    return UnpaddedBaseModelOutput(
+        last_hidden_state=torch.randn(TOTAL_TOKENS, HIDDEN),
+        indices=_INDICES.clone(),
+        seq_len=SEQ_LEN,
+        batch_size=BATCH,
+        cu_seqlens=_CU_SEQLENS.clone(),
+        hidden_states=hs,
+        attentions=None,
+    )
+
+
+def _mock_inner_model(task_model, return_value):
+    """Patch the inner BertBlocksModel's forward to return a fixed output.
+
+    PyTorch's Module.__setattr__ rejects non-Module values, so we patch
+    the forward method directly instead of replacing the module.
+    """
+    task_model.model.forward = MagicMock(return_value=return_value)
+
+
+def _consistent_outputs():
+    """Return (padded_out, unpadded_out) with identical non-padding hidden states.
+
+    The unpadded tensor is derived by gathering _INDICES from the flat padded tensor,
+    so non-padding positions carry exactly the same hidden vectors in both outputs.
+    Use this when asserting that padded and unpadded forward paths give the same result.
+    """
+    padded_hs = torch.randn(BATCH, SEQ_LEN, HIDDEN)
+    unpadded_hs = padded_hs.reshape(BATCH * SEQ_LEN, HIDDEN)[_INDICES]  # [TOTAL_TOKENS, HIDDEN]
+    padded_out = BaseModelOutput(last_hidden_state=padded_hs)
+    unpadded_out = UnpaddedBaseModelOutput(
+        last_hidden_state=unpadded_hs,
+        indices=_INDICES.clone(),
+        seq_len=SEQ_LEN,
+        batch_size=BATCH,
+        cu_seqlens=_CU_SEQLENS.clone(),
+    )
+    return padded_out, unpadded_out
+
+
+@pytest.fixture
+def base_config():
+    return BertBlocksConfig(
+        vocab_size=VOCAB,
+        hidden_size=HIDDEN,
+        num_blocks=1,
+        num_attention_heads=2,
+        intermediate_size=64,
+        max_sequence_length=SEQ_LEN,
+        pad_token_id=0,
+        mask_token_id=1,
+    )
+
+
+@pytest.fixture
+def cls_config():
+    return BertBlocksConfig(
+        vocab_size=VOCAB,
+        hidden_size=HIDDEN,
+        num_blocks=1,
+        num_attention_heads=2,
+        intermediate_size=64,
+        max_sequence_length=SEQ_LEN,
+        pad_token_id=0,
+        mask_token_id=1,
+        num_classes=NUM_CLASSES,
+        problem_type="single_label_classification",
+    )
+
+
+def _input_ids():
+    return torch.randint(2, VOCAB, (BATCH, SEQ_LEN))
+
+
+# ── BertBlocksForMaskedLM ────────────────────────────────────────────────────
+
+
+class TestBertBlocksForMaskedLM:
+    @pytest.mark.parametrize(
+        "base_output_fn",
+        [_padded_base_output, _unpadded_base_output],
+        ids=["padded", "unpadded"],
+    )
+    def test_logits_shape_no_labels(self, base_config, base_output_fn):
+        model = BertBlocksForMaskedLM(base_config)
+        _mock_inner_model(model, base_output_fn())
+        out = model(_input_ids())
+        assert out.loss is None
+        assert out.logits.shape == (BATCH, SEQ_LEN, VOCAB)
+
+    @pytest.mark.parametrize(
+        "base_output_fn",
+        [_padded_base_output, _unpadded_base_output],
+        ids=["padded", "unpadded"],
+    )
+    def test_logits_shape_with_labels(self, base_config, base_output_fn):
+        model = BertBlocksForMaskedLM(base_config)
+        _mock_inner_model(model, base_output_fn())
+        labels = torch.randint(0, VOCAB, (BATCH, SEQ_LEN))
+        out = model(_input_ids(), labels=labels)
+        assert out.loss is not None
+        assert out.loss.ndim == 0  # scalar
+        assert out.logits.shape == (BATCH, SEQ_LEN, VOCAB)
+
+    @pytest.mark.parametrize(
+        "base_output_fn",
+        [_padded_base_output, _unpadded_base_output],
+        ids=["padded", "unpadded"],
+    )
+    def test_hidden_states_passthrough(self, base_config, base_output_fn):
+        model = BertBlocksForMaskedLM(base_config)
+        _mock_inner_model(model, base_output_fn(hidden_states=True))
+        out = model(_input_ids(), output_hidden_states=True)
+        assert out.hidden_states is not None
+        assert all(h.shape == (BATCH, SEQ_LEN, HIDDEN) for h in out.hidden_states)
+
+    def test_loss_equivalence(self, base_config):
+        """Padded and unpadded paths must give the same loss.
+
+        In the padded path, cross-entropy ignores positions whose label is -100
+        (PyTorch default ignore_index). Setting labels to -100 at the two padding
+        positions makes the effective label set identical to the unpadded path.
+        """
+        padded_out, unpadded_out = _consistent_outputs()
+        labels = torch.randint(0, VOCAB, (BATCH, SEQ_LEN))
+        # Mask out padding positions so the padded path skips them in the loss.
+        padded_labels = labels.clone()
+        padded_labels.view(-1)[[SEQ_LEN - 1, BATCH * SEQ_LEN - 1]] = -100
+
+        model = BertBlocksForMaskedLM(base_config)
+
+        _mock_inner_model(model, padded_out)
+        padded_loss = model(_input_ids(), labels=padded_labels).loss
+
+        _mock_inner_model(model, unpadded_out)
+        unpadded_loss = model(_input_ids(), labels=labels).loss
+
+        assert torch.allclose(padded_loss, unpadded_loss)
+
+
+# ── BertBlocksForEnhancedMaskedLM ────────────────────────────────────────────
+
+
+class TestBertBlocksForEnhancedMaskedLM:
+    """EnhancedMaskedLM always operates on padded tensors (the extra block needs [B,S,H])."""
+
+    def test_logits_shape_no_labels(self, base_config):
+        model = BertBlocksForEnhancedMaskedLM(base_config)
+        _mock_inner_model(model, _padded_base_output())
+        # Also mock the extra block so it returns the expected padded shape.
+        hidden = torch.randn(BATCH, SEQ_LEN, HIDDEN)
+        model.enhanced_masking_block.forward = MagicMock(return_value=(hidden, None))
+        out = model(_input_ids())
+        assert out.loss is None
+        assert out.logits.shape == (BATCH, SEQ_LEN, VOCAB)
+
+    def test_logits_shape_with_labels(self, base_config):
+        model = BertBlocksForEnhancedMaskedLM(base_config)
+        _mock_inner_model(model, _padded_base_output())
+        hidden = torch.randn(BATCH, SEQ_LEN, HIDDEN)
+        model.enhanced_masking_block.forward = MagicMock(return_value=(hidden, None))
+        labels = torch.randint(0, VOCAB, (BATCH, SEQ_LEN))
+        out = model(_input_ids(), labels=labels)
+        assert out.loss is not None
+        assert out.loss.ndim == 0
+        assert out.logits.shape == (BATCH, SEQ_LEN, VOCAB)
+
+
+# ── BertBlocksForSequenceClassification ──────────────────────────────────────
+
+
+class TestBertBlocksForSequenceClassification:
+    @pytest.mark.parametrize(
+        "base_output_fn",
+        [_padded_base_output, _unpadded_base_output],
+        ids=["padded", "unpadded"],
+    )
+    def test_logits_shape_no_labels(self, cls_config, base_output_fn):
+        model = BertBlocksForSequenceClassification(cls_config)
+        _mock_inner_model(model, base_output_fn())
+        out = model(_input_ids())
+        assert out.loss is None
+        assert out.logits.shape == (BATCH, NUM_CLASSES)
+
+    @pytest.mark.parametrize(
+        "base_output_fn",
+        [_padded_base_output, _unpadded_base_output],
+        ids=["padded", "unpadded"],
+    )
+    def test_logits_shape_with_labels(self, cls_config, base_output_fn):
+        model = BertBlocksForSequenceClassification(cls_config)
+        _mock_inner_model(model, base_output_fn())
+        labels = torch.randint(0, NUM_CLASSES, (BATCH,))
+        out = model(_input_ids(), labels=labels)
+        assert out.loss is not None
+        assert out.loss.ndim == 0
+        assert out.logits.shape == (BATCH, NUM_CLASSES)
+
+    def test_loss_equivalence(self, cls_config):
+        """Padded and unpadded paths must give the same loss.
+
+        Both paths extract the CLS vector from position 0 of each sequence, which
+        maps to the same hidden state regardless of packing strategy, so no label
+        masking is needed.
+        """
+        padded_out, unpadded_out = _consistent_outputs()
+        labels = torch.randint(0, NUM_CLASSES, (BATCH,))
+
+        model = BertBlocksForSequenceClassification(cls_config)
+
+        _mock_inner_model(model, padded_out)
+        padded_loss = model(_input_ids(), labels=labels).loss
+
+        _mock_inner_model(model, unpadded_out)
+        unpadded_loss = model(_input_ids(), labels=labels).loss
+
+        assert torch.allclose(padded_loss, unpadded_loss)
+
+    def test_cls_from_cu_seqlens(self, cls_config):
+        """CLS features must come from the first token of each sequence (cu_seqlens[:-1])."""
+        model = BertBlocksForSequenceClassification(cls_config)
+        base_out = _unpadded_base_output()
+        _mock_inner_model(model, base_out)
+
+        out = model(_input_ids())
+
+        # Manually replicate what the forward should do and compare logits.
+        cls_indices = _CU_SEQLENS[:-1].long()
+        expected_cls = base_out.last_hidden_state[cls_indices]
+        with torch.no_grad():
+            expected_logits = model.classifier(model.head(expected_cls))
+
+        assert torch.allclose(out.logits, expected_logits)
+
+    @pytest.mark.parametrize(
+        "base_output_fn",
+        [_padded_base_output, _unpadded_base_output],
+        ids=["padded", "unpadded"],
+    )
+    def test_hidden_states_passthrough(self, cls_config, base_output_fn):
+        model = BertBlocksForSequenceClassification(cls_config)
+        _mock_inner_model(model, base_output_fn(hidden_states=True))
+        out = model(_input_ids(), output_hidden_states=True)
+        assert out.hidden_states is not None
+        assert all(h.shape == (BATCH, SEQ_LEN, HIDDEN) for h in out.hidden_states)
+
+
+# ── BertBlocksForTokenClassification ─────────────────────────────────────────
+
+
+class TestBertBlocksForTokenClassification:
+    @pytest.mark.parametrize(
+        "base_output_fn",
+        [_padded_base_output, _unpadded_base_output],
+        ids=["padded", "unpadded"],
+    )
+    def test_logits_shape_no_labels(self, cls_config, base_output_fn):
+        model = BertBlocksForTokenClassification(cls_config)
+        _mock_inner_model(model, base_output_fn())
+        out = model(_input_ids())
+        assert out.loss is None
+        assert out.logits.shape == (BATCH, SEQ_LEN, NUM_CLASSES)
+
+    @pytest.mark.parametrize(
+        "base_output_fn",
+        [_padded_base_output, _unpadded_base_output],
+        ids=["padded", "unpadded"],
+    )
+    def test_logits_shape_with_labels(self, cls_config, base_output_fn):
+        model = BertBlocksForTokenClassification(cls_config)
+        _mock_inner_model(model, base_output_fn())
+        labels = torch.randint(0, NUM_CLASSES, (BATCH, SEQ_LEN))
+        out = model(_input_ids(), labels=labels)
+        assert out.loss is not None
+        assert out.loss.ndim == 0
+        assert out.logits.shape == (BATCH, SEQ_LEN, NUM_CLASSES)
+
+    def test_loss_equivalence(self, cls_config):
+        """Padded and unpadded paths must give the same loss.
+
+        Setting labels to -100 at padding positions in the padded path makes the
+        effective label set identical to the unpadded path (which gathers only
+        non-padding positions before computing the loss).
+        """
+        padded_out, unpadded_out = _consistent_outputs()
+        labels = torch.randint(0, NUM_CLASSES, (BATCH, SEQ_LEN))
+        padded_labels = labels.clone()
+        padded_labels.view(-1)[[SEQ_LEN - 1, BATCH * SEQ_LEN - 1]] = -100
+
+        model = BertBlocksForTokenClassification(cls_config)
+
+        _mock_inner_model(model, padded_out)
+        padded_loss = model(_input_ids(), labels=padded_labels).loss
+
+        _mock_inner_model(model, unpadded_out)
+        unpadded_loss = model(_input_ids(), labels=labels).loss
+
+        assert torch.allclose(padded_loss, unpadded_loss)
+
+    def test_padding_positions_zeroed(self, cls_config):
+        """Logit values at padding positions should be 0 in unpadded mode."""
+        model = BertBlocksForTokenClassification(cls_config)
+        _mock_inner_model(model, _unpadded_base_output())
+        out = model(_input_ids())
+        # Positions 7 and 15 are the padding positions (see _INDICES definition).
+        padding_positions = [SEQ_LEN - 1, BATCH * SEQ_LEN - 1]
+        for flat_pos in padding_positions:
+            b, s = flat_pos // SEQ_LEN, flat_pos % SEQ_LEN
+            assert (out.logits[b, s] == 0).all()
+
+    @pytest.mark.parametrize(
+        "base_output_fn",
+        [_padded_base_output, _unpadded_base_output],
+        ids=["padded", "unpadded"],
+    )
+    def test_hidden_states_passthrough(self, cls_config, base_output_fn):
+        model = BertBlocksForTokenClassification(cls_config)
+        _mock_inner_model(model, base_output_fn(hidden_states=True))
+        out = model(_input_ids(), output_hidden_states=True)
+        assert out.hidden_states is not None
+        assert all(h.shape == (BATCH, SEQ_LEN, HIDDEN) for h in out.hidden_states)
+
+
+# ── BertBlocksForQuestionAnswering ────────────────────────────────────────────
+
+
+class TestBertBlocksForQuestionAnswering:
+    @pytest.mark.parametrize(
+        "base_output_fn",
+        [_padded_base_output, _unpadded_base_output],
+        ids=["padded", "unpadded"],
+    )
+    def test_span_logits_shape_no_positions(self, cls_config, base_output_fn):
+        model = BertBlocksForQuestionAnswering(cls_config)
+        _mock_inner_model(model, base_output_fn())
+        out = model(_input_ids())
+        assert out.loss is None
+        assert out.start_logits.shape == (BATCH, SEQ_LEN)
+        assert out.end_logits.shape == (BATCH, SEQ_LEN)
+
+    @pytest.mark.parametrize(
+        "base_output_fn",
+        [_padded_base_output, _unpadded_base_output],
+        ids=["padded", "unpadded"],
+    )
+    def test_span_logits_shape_with_positions(self, cls_config, base_output_fn):
+        model = BertBlocksForQuestionAnswering(cls_config)
+        _mock_inner_model(model, base_output_fn())
+        start_positions = torch.randint(0, SEQ_LEN, (BATCH,))
+        end_positions = torch.randint(0, SEQ_LEN, (BATCH,))
+        out = model(_input_ids(), start_positions=start_positions, end_positions=end_positions)
+        assert out.loss is not None
+        assert out.loss.ndim == 0
+        assert out.start_logits.shape == (BATCH, SEQ_LEN)
+        assert out.end_logits.shape == (BATCH, SEQ_LEN)
+
+    def test_logits_equivalence_at_valid_positions(self, cls_config):
+        """At non-padding positions, padded and unpadded paths must produce the same logits.
+
+        Full loss equivalence cannot be tested here: the QA loss uses CE over all
+        positions (softmax denominator includes padding slots), and the padded path
+        does not zero out padding logits while the unpadded path fills them with 0
+        via pad_output.  Comparing logits only at _INDICES positions sidesteps this
+        and still verifies that the underlying representations are consistent.
+        """
+        padded_out, unpadded_out = _consistent_outputs()
+
+        model = BertBlocksForQuestionAnswering(cls_config)
+
+        _mock_inner_model(model, padded_out)
+        padded_result = model(_input_ids())
+        padded_start = padded_result.start_logits.reshape(-1)[_INDICES]
+        padded_end = padded_result.end_logits.reshape(-1)[_INDICES]
+
+        _mock_inner_model(model, unpadded_out)
+        unpadded_result = model(_input_ids())
+        unpadded_start = unpadded_result.start_logits.reshape(-1)[_INDICES]
+        unpadded_end = unpadded_result.end_logits.reshape(-1)[_INDICES]
+
+        assert torch.allclose(padded_start, unpadded_start)
+        assert torch.allclose(padded_end, unpadded_end)
+
+    def test_padding_positions_zeroed(self, cls_config):
+        """Logit values at padding positions should be 0 in unpadded mode."""
+        model = BertBlocksForQuestionAnswering(cls_config)
+        _mock_inner_model(model, _unpadded_base_output())
+        out = model(_input_ids())
+        padding_positions = [SEQ_LEN - 1, BATCH * SEQ_LEN - 1]
+        for flat_pos in padding_positions:
+            b, s = flat_pos // SEQ_LEN, flat_pos % SEQ_LEN
+            assert out.start_logits[b, s].item() == 0.0
+            assert out.end_logits[b, s].item() == 0.0
+
+    @pytest.mark.parametrize(
+        "base_output_fn",
+        [_padded_base_output, _unpadded_base_output],
+        ids=["padded", "unpadded"],
+    )
+    def test_hidden_states_passthrough(self, cls_config, base_output_fn):
+        model = BertBlocksForQuestionAnswering(cls_config)
+        _mock_inner_model(model, base_output_fn(hidden_states=True))
+        out = model(_input_ids(), output_hidden_states=True)
+        assert out.hidden_states is not None
+        assert all(h.shape == (BATCH, SEQ_LEN, HIDDEN) for h in out.hidden_states)


### PR DESCRIPTION
Add a pad_output flag to the BertBlocks model. By default, outputs are padded to conform to the original transformers Bert implementation.
